### PR TITLE
Remove Scalaz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ headers := Map(
 libraryDependencies ++= {
 
   val scalazV = "7.2.26"
-  val catsV = "1.0.0"
+  val catsV = "3.5.1"
   val existV = "4.4.0"
   val algoliaV = "2.19.0"
   val akkaV = "2.5.16"

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ headers := Map(
 
 libraryDependencies ++= {
 
-  val scalazV = "7.2.26"
-  val catsV = "3.5.1"
+  val catsCoreV = "2.10.0"
+  val catsEffectV = "3.5.1"
   val existV = "4.4.0"
   val algoliaV = "2.19.0"
   val akkaV = "2.5.16"
@@ -32,9 +32,8 @@ libraryDependencies ++= {
   Seq(
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
     "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
-    "org.scalaz" %% "scalaz-core" % scalazV,
-    "org.typelevel" %% "cats-effect" % catsV,
-
+    "org.typelevel" %% "cats-core" % catsCoreV,
+    "org.typelevel" %% "cats-effect" % catsEffectV,
     "org.clapper" %% "grizzled-slf4j" % "1.3.2"
       exclude("org.slf4j", "slf4j-api"),
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/Checksum.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/Checksum.scala
@@ -23,8 +23,6 @@ import java.security.MessageDigest
 
 import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
-import scalaz.\/
-import scalaz.syntax.std.either._
 
 import scala.annotation.tailrec
 
@@ -50,7 +48,7 @@ object Checksum {
     * @param algorithm the algorithm to use for calculating the checksum.
     * @param bufferSize the size of the buffer to use when calculating the checksum (default is 16 KB)
     */
-  def checksum(file: Path, algorithm: Algorithm, bufferSize: Int = 16 * 1024) : Throwable \/ Array[Byte] = {
+  def checksum(file: Path, algorithm: Algorithm, bufferSize: Int = 16 * 1024) : Either[Throwable, Array[Byte]] = {
 
     def digestStream(is: InputStream, buf: Array[Byte], digest: MessageDigest): Array[Byte] = {
       @tailrec
@@ -79,7 +77,6 @@ object Checksum {
 
     checksumIO
       .attempt
-      .map(_.disjunction)
       .unsafeRunSync()
   }
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/Checksum.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/Checksum.scala
@@ -22,6 +22,7 @@ import java.nio.file.{Files, Path}
 import java.security.MessageDigest
 
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 import scalaz.\/
 import scalaz.syntax.std.either._
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/NodePathWithPredicates.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/NodePathWithPredicates.scala
@@ -8,9 +8,9 @@ import org.humanistika.exist.index.algolia.NodePathWithPredicates._
 import org.humanistika.exist.index.algolia.NodePathWithPredicates.ComponentType.ComponentType
 
 import scala.util.parsing.combinator._
-import scalaz.{-\/, \/, \/-}
-import scalaz.syntax.either._
 import scala.annotation.tailrec
+
+import cats.syntax.either._
 
 class NodePathWithPredicates(components: Seq[Component]) {
   def size = components.size
@@ -66,9 +66,9 @@ object NodePathWithPredicates {
   @throws[IllegalArgumentException]
   def apply(namespaces: Map[String, String], path: String): NodePathWithPredicates = {
     NodePathWithPredicatesParser.parsePath(namespaces, path) match {
-      case \/-(result) =>
+      case Right(result) =>
         result
-      case -\/(errorMsg) =>
+      case Left(errorMsg) =>
         throw new IllegalArgumentException(errorMsg)
     }
   }
@@ -77,12 +77,12 @@ object NodePathWithPredicates {
 
 object NodePathWithPredicatesParser extends RegexParsers {
 
-  def parsePath(namespaces: Map[Prefix, NamespaceURI], nodePathString: String): String \/ NodePathWithPredicates = {
+  def parsePath(namespaces: Map[Prefix, NamespaceURI], nodePathString: String): Either[String, NodePathWithPredicates] = {
     parseAll(path(namespaces), nodePathString) match {
       case Success(result, _) =>
-        result.right
+        result.asRight
       case NoSuccess(msg, _) =>
-        msg.left
+        msg.asLeft
     }
   }
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/Serializer.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/Serializer.scala
@@ -32,6 +32,7 @@ import org.w3c.dom.{Attr, Element, NamedNodeMap, Node, NodeList, Text}
 import scalaz.{-\/, \/, \/-}
 import scalaz.syntax.either._
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 
 object Serializer {
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/backend/IndexLocalStoreManagerActor.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/backend/IndexLocalStoreManagerActor.scala
@@ -39,6 +39,7 @@ import scala.util.{Failure, Success, Try}
 import scalaz.{-\/, \/, \/-}
 import scalaz.syntax.either._
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 import grizzled.slf4j.Logger
 import org.apache.commons.codec.binary.Base32
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/package.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/package.scala
@@ -28,20 +28,18 @@ import org.exist.storage.NodePath
 import org.humanistika.exist.index.algolia.IndexableRootObjectJsonSerializer.OBJECT_ID_FIELD_NAME
 import org.w3c.dom.{Attr, Element}
 
-import scalaz.\/
-
 package object algolia {
 
   type Name = String
   type IndexName = Name
 
-  type ElementOrAttributeImpl = ElementImpl \/ AttrImpl
-  type ElementOrAttribute = Element \/ Attr
+  type ElementOrAttributeImpl = Either[ElementImpl, AttrImpl]
+  type ElementOrAttribute = Either[Element, Attr]
   type ElementKV = (QName, String)  // qname and serialized XML as JSON
   type AttributeKV = (QName, String)  // substitute for org.exist.dom.memtree.AttrImpl as we have has trouble converting from org.exist.dom.persistent.AttrImpl
-  type ElementOrAttributeKV = ElementKV \/ AttributeKV
+  type ElementOrAttributeKV = Either[ElementKV, AttributeKV]
 
-  type IndexableAttributeOrObject = IndexableAttribute \/ IndexableObject
+  type IndexableAttributeOrObject = Either[IndexableAttribute, IndexableObject]
 
   object LiteralTypeConfig extends Enumeration {
     type LiteralTypeConfig = Value
@@ -56,7 +54,7 @@ package object algolia {
   type DocumentId = Int
   type objectID = String
 
-  @JsonSerialize(using=classOf[IndexableRootObjectJsonSerializer]) case class IndexableRootObject(collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[IndexableAttribute \/ IndexableObject])
+  @JsonSerialize(using=classOf[IndexableRootObjectJsonSerializer]) case class IndexableRootObject(collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[Either[IndexableAttribute, IndexableObject]])
   case class IndexableAttribute(name: Name, values: IndexableValues, literalType: LiteralTypeConfig.LiteralTypeConfig)
   case class IndexableObject(name: Name, values: IndexableValues)
 

--- a/src/test/scala/org/humanistika/exist/index/algolia/AlgoliaStreamListenerIntegrationSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/AlgoliaStreamListenerIntegrationSpec.scala
@@ -2,9 +2,6 @@ package org.humanistika.exist.index.algolia
 
 import java.nio.file.{Path, Paths}
 
-import scalaz._
-import Scalaz._
-
 import akka.actor.{ActorRef, ActorSystem}
 import org.exist.collections.CollectionConfiguration
 import org.exist.indexing.IndexWorker
@@ -18,6 +15,8 @@ import org.w3c.dom.Element
 
 import AlgoliaStreamListenerIntegrationSpec._
 import ExistAPIHelper._
+
+import cats.syntax.either._
 
 object AlgoliaStreamListenerIntegrationSpec {
   def getTestResource(filename: String): Path = Paths.get(classOf[AlgoliaStreamListenerIntegrationSpec].getClassLoader.getResource(filename).toURI)
@@ -58,25 +57,25 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.4.1"))),
-        -\/(("lemma", Seq("1.5.2.2.4.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.4.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.4.1"))),
+        Left(("lemma", Seq("1.5.2.2.4.3.3"))),
+        Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.6"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.6.1"))),
-        -\/(("lemma", Seq("1.5.2.2.6.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.6.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.6.1"))),
+        Left(("lemma", Seq("1.5.2.2.6.3.3"))),
+        Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.8"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.8.1"))),
-        -\/(("lemma", Seq("1.5.2.2.8.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.8.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.8.1"))),
+        Left(("lemma", Seq("1.5.2.2.8.3.3"))),
+        Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.10"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.10.1"))),
-        -\/(("lemma", Seq("1.5.2.2.10.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.10.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.10.1"))),
+        Left(("lemma", Seq("1.5.2.2.10.3.3"))),
+        Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.12"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.12.1"))),
-        -\/(("lemma", Seq("1.5.2.2.12.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.12.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.12.1"))),
+        Left(("lemma", Seq("1.5.2.2.12.3.3"))),
+        Left(("tr", Seq("1.5.2.2.12.9.3.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
     }
 
@@ -104,12 +103,12 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
-        -\/(("lemma", Seq(
+        Left(("lemma", Seq(
           "1.5.2.2.4.6.3",
           "1.5.2.2.4.8.5",
           "1.5.2.2.4.12.5")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.6"), None, Seq(
-        -\/(("lemma", Seq(
+        Left(("lemma", Seq(
           "1.5.2.2.6.6.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
     }
@@ -138,24 +137,24 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.4.1"))),
-        -\/(("lemma", Seq("1.5.2.2.4.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.4.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.4.1"))),
+        Left(("lemma", Seq("1.5.2.2.4.3.3"))),
+        Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.6"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.6.1"))),
-        -\/(("lemma", Seq("1.5.2.2.6.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.6.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.6.1"))),
+        Left(("lemma", Seq("1.5.2.2.6.3.3"))),
+        Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.8"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.8.1"))),
-        -\/(("lemma", Seq("1.5.2.2.8.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.8.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.8.1"))),
+        Left(("lemma", Seq("1.5.2.2.8.3.3"))),
+        Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.10"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.10.1"))),
-        -\/(("inverse-lemma", Seq("1.5.2.2.10.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.10.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.10.1"))),
+        Left(("inverse-lemma", Seq("1.5.2.2.10.3.3"))),
+        Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.12"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.12.1"))),
-        -\/(("lemma", Seq("1.5.2.2.12.3.3")))))
+        Left(("dict", Seq("1.5.2.2.12.1"))),
+        Left(("lemma", Seq("1.5.2.2.12.3.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
     }
 
@@ -182,8 +181,8 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
-        -\/(("trde", Seq("1.5.2.2.4.14.6.3", "1.5.2.2.4.16.6.3", "1.5.2.2.4.18.6.3", "1.5.2.2.4.18.8.3", "1.5.2.2.4.22.6.3", "1.5.2.2.4.24.8.3", "1.5.2.2.4.26.6.3"))),
-        -\/(("trla", Seq("1.5.2.2.4.14.8.3", "1.5.2.2.4.14.10.5", "1.5.2.2.4.16.8.3", "1.5.2.2.4.18.10.3", "1.5.2.2.4.18.12.3", "1.5.2.2.4.22.8.3", "1.5.2.2.4.24.10.3", "1.5.2.2.4.26.8.3")))))
+        Left(("trde", Seq("1.5.2.2.4.14.6.3", "1.5.2.2.4.16.6.3", "1.5.2.2.4.18.6.3", "1.5.2.2.4.18.8.3", "1.5.2.2.4.22.6.3", "1.5.2.2.4.24.8.3", "1.5.2.2.4.26.6.3"))),
+        Left(("trla", Seq("1.5.2.2.4.14.8.3", "1.5.2.2.4.14.10.5", "1.5.2.2.4.16.8.3", "1.5.2.2.4.18.10.3", "1.5.2.2.4.18.12.3", "1.5.2.2.4.22.8.3", "1.5.2.2.4.24.10.3", "1.5.2.2.4.26.8.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
     }
 
@@ -212,25 +211,25 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.4"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.4.1"))),
-        -\/(("lemma", Seq("1.5.2.2.4.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.4.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.4.1"))),
+        Left(("lemma", Seq("1.5.2.2.4.3.3"))),
+        Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.6"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.6.1"))),
-        -\/(("lemma", Seq("1.5.2.2.6.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.6.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.6.1"))),
+        Left(("lemma", Seq("1.5.2.2.6.3.3"))),
+        Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.8"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.8.1"))),
-        -\/(("lemma", Seq("1.5.2.2.8.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.8.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.8.1"))),
+        Left(("lemma", Seq("1.5.2.2.8.3.3"))),
+        Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.10"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.10.1"))),
-        -\/(("lemma", Seq("1.5.2.2.10.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.10.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.10.1"))),
+        Left(("lemma", Seq("1.5.2.2.10.3.3"))),
+        Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.12"), None, Seq(
-        -\/(("dict", Seq("1.5.2.2.12.1"))),
-        -\/(("lemma", Seq("1.5.2.2.12.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.12.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.12.1"))),
+        Left(("lemma", Seq("1.5.2.2.12.3.3"))),
+        Left(("tr", Seq("1.5.2.2.12.9.3.3")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -259,25 +258,25 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.4"), Some("VSK.SR.Adam"), Seq(
-        -\/(("dict", Seq("1.5.2.2.4.1"))),
-        -\/(("lemma", Seq("1.5.2.2.4.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.4.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.4.1"))),
+        Left(("lemma", Seq("1.5.2.2.4.3.3"))),
+        Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.6"), Some("VSK.SR.Addam"), Seq(
-        -\/(("dict", Seq("1.5.2.2.6.1"))),
-        -\/(("lemma", Seq("1.5.2.2.6.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.6.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.6.1"))),
+        Left(("lemma", Seq("1.5.2.2.6.3.3"))),
+        Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.8"), Some("VSK.SR.Adamm"), Seq(
-        -\/(("dict", Seq("1.5.2.2.8.1"))),
-        -\/(("lemma", Seq("1.5.2.2.8.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.8.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.8.1"))),
+        Left(("lemma", Seq("1.5.2.2.8.3.3"))),
+        Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.10"), Some("VSK.SR.Adammm"), Seq(
-        -\/(("dict", Seq("1.5.2.2.10.1"))),
-        -\/(("lemma", Seq("1.5.2.2.10.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.10.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.10.1"))),
+        Left(("lemma", Seq("1.5.2.2.10.3.3"))),
+        Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.12"), Some("VSK.SR.Adammmm"), Seq(
-        -\/(("dict", Seq("1.5.2.2.12.1"))),
-        -\/(("lemma", Seq("1.5.2.2.12.3.3"))),
-        -\/(("tr", Seq("1.5.2.2.12.9.3.3")))))
+        Left(("dict", Seq("1.5.2.2.12.1"))),
+        Left(("lemma", Seq("1.5.2.2.12.3.3"))),
+        Left(("tr", Seq("1.5.2.2.12.9.3.3")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -305,7 +304,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
-        \/-(("e-e", Seq("4.6.2.2.4.7")))))
+        Right(("e-e", Seq("4.6.2.2.4.7")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -333,7 +332,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
-        \/-(("e-e", Seq("4.6.2.2.4.7")))))
+        Right(("e-e", Seq("4.6.2.2.4.7")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -361,7 +360,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
-        \/-(("e-e", Seq("4.6.2.2.4.7")))))
+        Right(("e-e", Seq("4.6.2.2.4.7")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -389,7 +388,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("3.5.2.2.4"), Some("VSK.SR.баба2"), Seq(
-        \/-(("e-e", Seq("3.5.2.2.4.8", "3.5.2.2.4.10", "3.5.2.2.4.12", "3.5.2.2.4.14")))))
+        Right(("e-e", Seq("3.5.2.2.4.8", "3.5.2.2.4.10", "3.5.2.2.4.12", "3.5.2.2.4.14")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -417,9 +416,9 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
       assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("VSK.SR.џукела"), Seq(
-        -\/(("l", Seq("4.6.2.2.4.4.3"))),
-        -\/(("t-de", Seq("4.6.2.2.4.8.3.3"))),
-        -\/(("t-la", Seq("4.6.2.2.4.8.5.3")))))
+        Left(("l", Seq("4.6.2.2.4.4.3"))),
+        Left(("t-de", Seq("4.6.2.2.4.8.3.3"))),
+        Left(("t-la", Seq("4.6.2.2.4.8.5.3")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
 
@@ -430,7 +429,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
   type IndexableAttributeNameAndValueIds = NameAndValueIds
   type IndexableObjectNameAndValueIds = NameAndValueIds
 
-  private def assertAdd(addMsg: Add)(indexName: IndexName, collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[IndexableAttributeNameAndValueIds \/ IndexableObjectNameAndValueIds]) = {
+  private def assertAdd(addMsg: Add)(indexName: IndexName, collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[Either[IndexableAttributeNameAndValueIds, IndexableObjectNameAndValueIds]]) = {
     addMsg.indexName mustEqual indexName
     addMsg.indexableRootObject.collectionPath mustEqual collectionPath
     addMsg.indexableRootObject.collectionId mustEqual collectionId
@@ -439,7 +438,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
     addMsg.indexableRootObject.nodeId mustEqual nodeId
     addMsg.indexableRootObject.userSpecifiedNodeId mustEqual userSpecifiedNodeId
 
-    val actualChildren: Seq[IndexableAttributeNameAndValueIds \/ IndexableObjectNameAndValueIds] = addMsg.indexableRootObject.children.map(_.map(indexableObject => (indexableObject.name, indexableObject.values.map(_.id))).leftMap(indexableAttribute => (indexableAttribute.name, indexableAttribute.values.map(_.id))))
+    val actualChildren: Seq[Either[IndexableAttributeNameAndValueIds, IndexableObjectNameAndValueIds]] = addMsg.indexableRootObject.children.map(_.map(indexableObject => (indexableObject.name, indexableObject.values.map(_.id))).leftMap(indexableAttribute => (indexableAttribute.name, indexableAttribute.values.map(_.id))))
     actualChildren mustEqual children
   }
 
@@ -487,9 +486,9 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
         (collectionId, docId)
       }
     }.flatMap(identity) match {
-      case -\/(e) =>
+      case Left(e) =>
         throw e
-      case \/-(result) =>
+      case Right(result) =>
         result
     }
   }

--- a/src/test/scala/org/humanistika/exist/index/algolia/DOMHelper.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/DOMHelper.scala
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 import javax.xml.parsers.DocumentBuilderFactory
 import org.w3c.dom.{Attr, Document, Element, Node}
 import scalaz.{-\/, \/, \/-}

--- a/src/test/scala/org/humanistika/exist/index/algolia/DOMHelper.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/DOMHelper.scala
@@ -5,10 +5,9 @@ import java.nio.charset.StandardCharsets
 
 import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
+import cats.syntax.either._
 import javax.xml.parsers.DocumentBuilderFactory
 import org.w3c.dom.{Attr, Document, Element, Node}
-import scalaz.{-\/, \/, \/-}
-import scalaz.syntax.either._
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success}
@@ -24,10 +23,10 @@ object DOMHelper {
       IO {
         documentBuilder.parse(is)
       }
-    }.redeem(_.left, _.right).unsafeRunSync() match {
-      case \/-(s) =>
+    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
+      case Right(s) =>
         s
-      case -\/(t) =>
+      case Left(t) =>
         throw t
     }
   }

--- a/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
@@ -10,10 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.humanistika.exist.index.algolia.Serializer.{serializeElementForAttribute, serializeElementForObject}
 import org.specs2.Specification
 import org.w3c.dom.{Attr, Document, Element, Node}
-import scalaz._
-import Scalaz._
 import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
+import cats.syntax.either._
 
 import scala.util.{Failure, Success}
 
@@ -83,28 +82,28 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
 
   def e5 = {
     val attr1_kv = new AttributeKV(new QName("value"), "hello")
-    val attributes = Seq(-\/(IndexableAttribute("attr1", Seq(IndexableValue("1.1", \/-(attr1_kv))), LiteralTypeConfig.String)))
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.String)))
     val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"attr1":"hello"}"""
   }
 
   def e6 = {
     val attr1_kv = new AttributeKV(new QName("value"), "99.9")
-    val attributes = Seq(-\/(IndexableAttribute("attr1", Seq(IndexableValue("1.1", \/-(attr1_kv))), LiteralTypeConfig.Float)))
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Float)))
     val indexableRootObject = IndexableRootObject("/db/a1", 2, 49, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"2/49/1","collection":"/db/a1","documentID":49,"attr1":99.9}"""
   }
 
   def e7 = {
     val attr1_kv = new AttributeKV(new QName("value"), "1012")
-    val attributes = Seq(-\/(IndexableAttribute("attr1", Seq(IndexableValue("1.1", \/-(attr1_kv))), LiteralTypeConfig.Integer)))
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Integer)))
     val indexableRootObject = IndexableRootObject("/db/a1", 9, 50, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"9/50/1","collection":"/db/a1","documentID":50,"attr1":1012}"""
   }
 
   def e8 = {
     val attr1_kv = new AttributeKV(new QName("value"), "true")
-    val attributes = Seq(-\/(IndexableAttribute("attr1", Seq(IndexableValue("1.1", \/-(attr1_kv))), LiteralTypeConfig.Boolean)))
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Boolean)))
     val indexableRootObject = IndexableRootObject("/db/a1", 3, 51, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"3/51/1","collection":"/db/a1","documentID":51,"attr1":true}"""
   }
@@ -112,7 +111,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e9 = {
     val attr1_kv = new AttributeKV(new QName("x"), "99.9")
     val attr2_kv = new AttributeKV(new QName("y"), "11.4")
-    val attributes = Seq(-\/(IndexableAttribute("attr1", Seq(IndexableValue("1.1", \/-(attr1_kv))), LiteralTypeConfig.Float)), -\/(IndexableAttribute("attr2", Seq(IndexableValue("1.2", \/-(attr2_kv))), LiteralTypeConfig.Float)))
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Float)), Left(IndexableAttribute("attr2", Seq(IndexableValue("1.2", Right(attr2_kv))), LiteralTypeConfig.Float)))
     val indexableRootObject = IndexableRootObject("/db/a1", 3, 52, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"3/52/1","collection":"/db/a1","documentID":52,"attr1":99.9,"attr2":11.4}"""
   }
@@ -123,8 +122,8 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val attr2_1_kv = new AttributeKV(new QName("y"), "11.4")
     val attr2_2_kv = new AttributeKV(new QName("y"), "10.2")
     val attributes = Seq(
-      -\/(IndexableAttribute("xx", Seq(IndexableValue("1.1", \/-(attr1_1_kv)), IndexableValue("2.1", \/-(attr1_2_kv))), LiteralTypeConfig.Float)),
-      -\/(IndexableAttribute("yy", Seq(IndexableValue("1.2", \/-(attr2_1_kv)), IndexableValue("2.2", \/-(attr2_2_kv))), LiteralTypeConfig.Float))
+      Left(IndexableAttribute("xx", Seq(IndexableValue("1.1", Right(attr1_1_kv)), IndexableValue("2.1", Right(attr1_2_kv))), LiteralTypeConfig.Float)),
+      Left(IndexableAttribute("yy", Seq(IndexableValue("1.2", Right(attr2_1_kv)), IndexableValue("2.2", Right(attr2_2_kv))), LiteralTypeConfig.Float))
     )
     val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/42/1","collection":"/db/a1","documentID":42,"xx":[99.9,202.2],"yy":[11.4,10.2]}"""
@@ -132,28 +131,28 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
 
   def e11 = {
     val elem1_kv = new ElementKV(new QName("w"), "hello")
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.String)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/48/1","collection":"/db/a1","documentID":48,"elem1":"hello"}"""
   }
 
   def e12 = {
     val elem1_kv = new ElementKV(new QName("x"), "99.9")
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.Float)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Float)))
     val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"elem1":99.9}"""
   }
 
   def e13 = {
     val elem1_kv = new ElementKV(new QName("y"), "1012")
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.Integer)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Integer)))
     val indexableRootObject = IndexableRootObject("/db/a1", 2, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"2/48/1","collection":"/db/a1","documentID":48,"elem1":1012}"""
   }
 
   def e14 = {
     val elem1_kv = new ElementKV(new QName("z"), "true")
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.Boolean)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Boolean)))
     val indexableRootObject = IndexableRootObject("/db/a1", 1, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"1/48/1","collection":"/db/a1","documentID":48,"elem1":true}"""
   }
@@ -161,14 +160,14 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e15 = {
     val elem1_kv = new ElementKV(new QName("x"), "99.9")
     val elem2_kv = new ElementKV(new QName("y"), "11.3")
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.Float)), -\/(IndexableAttribute("elem2", Seq(IndexableValue("1.2", -\/(elem2_kv))), LiteralTypeConfig.Float)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Float)), Left(IndexableAttribute("elem2", Seq(IndexableValue("1.2", Left(elem2_kv))), LiteralTypeConfig.Float)))
     val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"elem1":99.9,"elem2":11.3}"""
   }
 
   def e16 = {
     val elem1_kv = new ElementKV(new QName("x"), "hello world")
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.String)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
     val indexableRootObject = IndexableRootObject("/db/a1", 23, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"23/48/1","collection":"/db/a1","documentID":48,"elem1":"hello world"}"""
   }
@@ -176,7 +175,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e17 = {
     val elem1 = elem(dom("""<x y="17">hello <b>world</b></x>"""), "x")
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(elem1).valueOr(ts => throw ts.head))
-    val attributes = Seq(-\/(IndexableAttribute("elem1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.String)))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
     val indexableRootObject = IndexableRootObject("/db/a1", 23, 48, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"23/48/1","collection":"/db/a1","documentID":48,"elem1":"hello world"}"""
   }
@@ -189,8 +188,8 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val elem2_1_kv = new ElementKV(new QName("y"), serializeElementForAttribute(childElem(pos(0), "y")).valueOr(ts => throw ts.head))
     val elem2_2_kv = new ElementKV(new QName("y"), serializeElementForAttribute(childElem(pos(1), "y")).valueOr(ts => throw ts.head))
     val attributes = Seq(
-      -\/(IndexableAttribute("xx", Seq(IndexableValue("1.1", -\/(elem1_1_kv)), IndexableValue("2.1", -\/(elem1_2_kv))), LiteralTypeConfig.Float)),
-      -\/(IndexableAttribute("yy", Seq(IndexableValue("1.2", -\/(elem2_1_kv)), IndexableValue("2.2", -\/(elem2_2_kv))), LiteralTypeConfig.Float))
+      Left(IndexableAttribute("xx", Seq(IndexableValue("1.1", Left(elem1_1_kv)), IndexableValue("2.1", Left(elem1_2_kv))), LiteralTypeConfig.Float)),
+      Left(IndexableAttribute("yy", Seq(IndexableValue("1.2", Left(elem2_1_kv)), IndexableValue("2.2", Left(elem2_2_kv))), LiteralTypeConfig.Float))
     )
     val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/42/1","collection":"/db/a1","documentID":42,"xx":[123.4,456.12],"yy":[-17.45,15.67]}"""
@@ -204,8 +203,8 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val elem2_1_kv = new ElementKV(new QName("y"), serializeElementForAttribute(childElem(pos(0), "y")).valueOr(ts => throw ts.head))
     val elem2_2_kv = new ElementKV(new QName("y"), serializeElementForAttribute(childElem(pos(1), "y")).valueOr(ts => throw ts.head))
     val attributes = Seq(
-      -\/(IndexableAttribute("xx", Seq(IndexableValue("1.1", -\/(elem1_1_kv)), IndexableValue("2.1", -\/(elem1_2_kv))), LiteralTypeConfig.Float)),
-      -\/(IndexableAttribute("yy", Seq(IndexableValue("1.2", -\/(elem2_1_kv)), IndexableValue("2.2", -\/(elem2_2_kv))), LiteralTypeConfig.Float))
+      Left(IndexableAttribute("xx", Seq(IndexableValue("1.1", Left(elem1_1_kv)), IndexableValue("2.1", Left(elem1_2_kv))), LiteralTypeConfig.Float)),
+      Left(IndexableAttribute("yy", Seq(IndexableValue("1.2", Left(elem2_1_kv)), IndexableValue("2.2", Left(elem2_2_kv))), LiteralTypeConfig.Float))
     )
     val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/42/1","collection":"/db/a1","documentID":42,"xx":[123.4,456.12],"yy":[-17.45,15.67]}"""
@@ -216,7 +215,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val elem1 = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(elem1).valueOr(ts => throw ts.head))
     val attributes = Seq(
-      -\/(IndexableAttribute("obj1", Seq(IndexableValue("1.1", -\/(elem1_kv))), LiteralTypeConfig.String))
+      Left(IndexableAttribute("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String))
     )
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual
@@ -225,7 +224,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
 
   def e21 = {
     val attr1_kv = new AttributeKV(new QName("value"), "hello")
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(IndexableValue("1.1", \/-(attr1_kv))))))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Right(attr1_kv))))))
     val indexableRootObject = IndexableRootObject("/db/a1", 45, 48, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"45/48/1","collection":"/db/a1","documentID":48,"obj1":"hello"}"""
   }
@@ -233,9 +232,9 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e22 = {
     val attr1_1_kv = new AttributeKV(new QName("value"), "hello")
     val attr1_2_kv = new AttributeKV(new QName("value"), "world")
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(
-      IndexableValue("1.1.1", \/-(attr1_1_kv)),
-      IndexableValue("1.2.1", \/-(attr1_2_kv))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(
+      IndexableValue("1.1.1", Right(attr1_1_kv)),
+      IndexableValue("1.2.1", Right(attr1_2_kv))
     ))))
     val indexableRootObject = IndexableRootObject("/db/a1", 46, 49, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"46/49/1","collection":"/db/a1","documentID":49,"obj1":["hello","world"]}"""
@@ -244,7 +243,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e23 = {
     val elem1 = elem(dom("""<w><x>hello</x><y>world</y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(IndexableValue("1.1", -\/(elem1_kv))))))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
     val indexableRootObject = IndexableRootObject("/db/a1", 5, 48, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"5/48/1","collection":"/db/a1","documentID":48,"obj1":{"nodeId":"1.1","x":"hello","y":"world"}}"""
   }
@@ -252,7 +251,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e24 = {
     val elem1 = elem(dom("""<w><x>hello</x><y><z>world</z><zz>again</zz></y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(IndexableValue("1.1", -\/(elem1_kv))))))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
     val indexableRootObject = IndexableRootObject("/db/a1", 2, 49, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"2/49/1","collection":"/db/a1","documentID":49,"obj1":{"nodeId":"1.1","x":"hello","y":{"z":"world","zz":"again"}}}"""
   }
@@ -260,7 +259,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e25 = {
     val elem1 = elem(dom("""<w><x>hello</x><y>world</y><y>again</y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(IndexableValue("1.1", -\/(elem1_kv))))))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
     val indexableRootObject = IndexableRootObject("/db/a1", 3, 50, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"3/50/1","collection":"/db/a1","documentID":50,"obj1":{"nodeId":"1.1","x":"hello","y":["world","again"]}}"""
   }
@@ -268,7 +267,7 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   def e26 = {
     val elem1 = elem(dom("""<w><x>hello</x><y><yy>world</yy><yy>again</yy></y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(IndexableValue("1.1", -\/(elem1_kv))))))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 51, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/51/1","collection":"/db/a1","documentID":51,"obj1":{"nodeId":"1.1","x":"hello","y":{"yy":["world","again"]}}}"""
   }
@@ -278,9 +277,9 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val ww = elems(dom1, "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(ww(0)).valueOr(ts => throw ts.head))
     val elem2_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(ww(1)).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(
-      IndexableValue("1.1", -\/(elem1_kv)),
-      IndexableValue("1.2", -\/(elem2_kv))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(
+      IndexableValue("1.1", Left(elem1_kv)),
+      IndexableValue("1.2", Left(elem2_kv))
     ))))
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 52, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/52/1","collection":"/db/a1","documentID":52,"obj1":[{"nodeId":"1.1","x":"hello","y":{"yy":["world","again"]}},{"nodeId":"1.2","x":"goodbye","y":{"yy":["until","next time"]}}]}"""
@@ -290,8 +289,8 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val dom1 = dom("""<parts><w><x>hello</x></w></parts>""")
     val elem1 = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(
-      IndexableValue("1.1", -\/(elem1_kv))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(
+      IndexableValue("1.1", Left(elem1_kv))
     ))))
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual
@@ -302,8 +301,8 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val dom1 = dom("""<parts><w><x type="something"/></w></parts>""")
     val elem1 = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(
-      IndexableValue("1.1", -\/(elem1_kv))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(
+      IndexableValue("1.1", Left(elem1_kv))
     ))))
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual
@@ -314,8 +313,8 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
     val dom1 = dom("""<parts><w><x type="something">hello</x></w></parts>""")
     val elem = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem).valueOr(ts => throw ts.head))
-    val objects = Seq(\/-(IndexableObject("obj1", Seq(
-      IndexableValue("1.1", -\/(elem1_kv))
+    val objects = Seq(Right(IndexableObject("obj1", Seq(
+      IndexableValue("1.1", Left(elem1_kv))
     ))))
     val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual
@@ -329,11 +328,11 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
         mapper.writeValue(writer, indexableRootObject)
         writer.toString
       }
-    }.redeem(_.left, _.right)
+    }.redeem(_.asLeft, _.asRight)
       .unsafeRunSync() match {
-      case \/-(s) =>
+      case Right(s) =>
         s
-      case -\/(t) =>
+      case Left(t) =>
         throw t
     }
   }

--- a/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
@@ -13,6 +13,7 @@ import org.w3c.dom.{Attr, Document, Element, Node}
 import scalaz._
 import Scalaz._
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 
 import scala.util.{Failure, Success}
 

--- a/src/test/scala/org/humanistika/exist/index/algolia/LocalIndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/LocalIndexableRootObjectJsonSerializerSpec.scala
@@ -10,9 +10,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
-
-import scalaz._
-import Scalaz._
+import cats.syntax.either._
 
 class LocalIndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"""
   This is a specification to check the JSON Serialization of IndexableRootObject
@@ -41,10 +39,10 @@ class LocalIndexableRootObjectJsonSerializerSpec extends Specification { def is 
       IO {
         writer.write(json)
       }
-    }.redeem(_.left, _.right).unsafeRunSync() match {
-      case \/-(_) =>
+    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
+      case Right(_) =>
         p
-      case -\/(t) =>
+      case Left(t) =>
         throw t
     }
   }
@@ -56,10 +54,10 @@ class LocalIndexableRootObjectJsonSerializerSpec extends Specification { def is 
         mapper.writeValue(writer, obj)
         writer.toString
       }
-    }.redeem(_.left, _.right).unsafeRunSync() match {
-      case \/-(s) =>
+    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
+      case Right(s) =>
         s
-      case -\/(t) =>
+      case Left(t) =>
         throw t
     }
   }

--- a/src/test/scala/org/humanistika/exist/index/algolia/LocalIndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/LocalIndexableRootObjectJsonSerializerSpec.scala
@@ -9,6 +9,7 @@ import org.specs2.Specification
 import java.nio.charset.StandardCharsets.UTF_8
 
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 
 import scalaz._
 import Scalaz._

--- a/src/test/scala/org/humanistika/exist/index/algolia/SerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/SerializerSpec.scala
@@ -7,12 +7,10 @@ import java.nio.charset.StandardCharsets
 
 import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
+import cats.syntax.either._
 import javax.xml.parsers.DocumentBuilderFactory
 import org.specs2.Specification
 import org.w3c.dom.{Document, Element, Node}
-
-import scalaz._
-import Scalaz._
 
 class SerializerSpec extends Specification { def is = s2"""
     This is a specification to check the JSON Serialization of XML nodes
@@ -35,52 +33,52 @@ class SerializerSpec extends Specification { def is = s2"""
 
   def e1 = {
     val elem1 = elem(dom("""<w>hello</w>"""), "w")
-    serializeElementForAttribute(elem1) mustEqual \/-("hello")
+    serializeElementForAttribute(elem1) mustEqual Right("hello")
   }
 
   def e2 = {
     val elem1 = elem(dom("""<x>hello <b>world<c> again</c></b></x>"""), "x")
-    serializeElementForAttribute(elem1) mustEqual \/-("hello world again")
+    serializeElementForAttribute(elem1) mustEqual Right("hello world again")
   }
 
   def e3 = {
     val elem1 = elem(dom("""<w a1="goodbye">hello</w>"""), "w")
-    serializeElementForAttribute(elem1) mustEqual \/-("hello")
+    serializeElementForAttribute(elem1) mustEqual Right("hello")
   }
 
   def e4 = {
     val elem1 = elem(dom("""<x>hello <b a2="what?">world<c a3="hmm!"> again</c></b></x>"""), "x")
-    serializeElementForAttribute(elem1) mustEqual \/-("hello world again")
+    serializeElementForAttribute(elem1) mustEqual Right("hello world again")
   }
 
   def e5 = {
     val elem1 = elem(dom("""<w>hello</w>"""), "w")
-    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual \/-(""","#text":"hello"""")
+    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual Right(""","#text":"hello"""")
   }
 
   def e6 = {
     val elem1 = elem(dom("""<x>hello <b>world<c> again</c></b></x>"""), "x")
-    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual \/-(""","#text":"hello ","b":{"#text":"world","c":" again"}""")
+    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual Right(""","#text":"hello ","b":{"#text":"world","c":" again"}""")
   }
 
   def e7 = {
     val elem1 = elem(dom("""<w a1="goodbye">hello</w>"""), "w")
-    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual \/-(""","a1":"goodbye","#text":"hello"""")
+    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual Right(""","a1":"goodbye","#text":"hello"""")
   }
 
   def e8 = {
     val elem1 = elem(dom("""<x>hello <b a2="what?">world<c a3="hmm!"> again</c></b> yup</x>"""), "x")
-    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual \/-(""","#text":["hello "," yup"],"b":{"a2":"what?","#text":"world","c":{"a3":"hmm!","#text":" again"}}""")
+    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual Right(""","#text":["hello "," yup"],"b":{"a2":"what?","#text":"world","c":{"a3":"hmm!","#text":" again"}}""")
   }
 
   def e9 = {
     val elem1 = elem(dom("""<etym>(<lang value="tr">тур.</lang><mentioned xml:lang="tr">cüce</mentioned>)</etym>"""), "etym")
-    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual \/-(""","#text":["(",")"],"lang":{"value":"tr","#text":"тур."},"mentioned":{"xml:lang":"tr","#text":"cüce"}""")
+    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual Right(""","#text":["(",")"],"lang":{"value":"tr","#text":"тур."},"mentioned":{"xml:lang":"tr","#text":"cüce"}""")
   }
 
   def e10 = {
     val elem1 = elem(dom("""<etym source="#thirdEd"><lang value="tr">[*]</lang></etym>"""), "etym")
-    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual \/-(""","source":"#thirdEd","lang":{"value":"tr","#text":"[*]"}""")
+    serializeElementForObject("my-object", Map.empty, Map.empty)(elem1) mustEqual Right(""","source":"#thirdEd","lang":{"value":"tr","#text":"[*]"}""")
   }
 
   private lazy val documentBuilderFactory = DocumentBuilderFactory.newInstance()
@@ -90,10 +88,10 @@ class SerializerSpec extends Specification { def is = s2"""
       IO {
         documentBuilder.parse(is)
       }
-    }.redeem(_.left, _.right).unsafeRunSync() match {
-      case \/-(s) =>
+    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
+      case Right(s) =>
         s
-      case -\/(t) =>
+      case Left(t) =>
         throw t
     }
   }

--- a/src/test/scala/org/humanistika/exist/index/algolia/SerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/SerializerSpec.scala
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 import javax.xml.parsers.DocumentBuilderFactory
 import org.specs2.Specification
 import org.w3c.dom.{Document, Element, Node}


### PR DESCRIPTION
We were only using ScalaZ for its disjunction class, but ScalaZ is now deprecated, so instead we can use Scala's Either class instead along with Cat's Either Syntax enhancements.