### PR TITLE
Remove cats-effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ headers := Map(
 libraryDependencies ++= {
 
   val catsCoreV = "2.10.0"
-  val catsEffectV = "3.5.1"
   val existV = "4.4.0"
   val algoliaV = "2.19.0"
   val akkaV = "2.5.16"
@@ -33,7 +32,6 @@ libraryDependencies ++= {
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
     "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
     "org.typelevel" %% "cats-core" % catsCoreV,
-    "org.typelevel" %% "cats-effect" % catsEffectV,
     "org.clapper" %% "grizzled-slf4j" % "1.3.2"
       exclude("org.slf4j", "slf4j-api"),
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/AlgoliaIndexWorker.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/AlgoliaIndexWorker.scala
@@ -29,9 +29,8 @@ import org.exist.xquery.XQueryContext
 import org.exist_db.collection_config._1.Algolia
 import org.w3c.dom.{Element, Node, NodeList}
 import AlgoliaIndexWorker._
-import akka.actor.{ActorPath, ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem}
 import org.apache.logging.log4j.{LogManager, Logger}
-import org.humanistika.exist.index.algolia.backend.IncrementalIndexingManagerActor
 import org.humanistika.exist.index.algolia.backend.IncrementalIndexingManagerActor.RemoveForCollection
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/org/humanistika/exist/index/algolia/With.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/With.scala
@@ -1,0 +1,32 @@
+package org.humanistika.exist.index.algolia
+
+import scala.util.{Failure, Success, Try}
+
+// TODO(AR) replace with `Using` in Scala 2.13
+object With {
+  def apply[R, A](acquire: => R)(release: R => Unit)(f: R => A): Try[A] = {
+    val r = acquire
+    try {
+      val a = f(r)
+      Success(a)
+    } catch {
+      case t: Throwable =>
+        Failure(t)
+    } finally {
+      release(r)
+    }
+  }
+
+  def apply[R <: AutoCloseable, A](acquire: => R)(f: R => A): Try[A] = {
+    val r = acquire
+    try {
+      val a = f(r)
+      Success(a)
+    } catch {
+      case t: Throwable =>
+        Failure(t)
+    } finally {
+      r.close()
+    }
+  }
+}

--- a/src/test/scala/org/humanistika/exist/index/algolia/DOMHelper.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/DOMHelper.scala
@@ -2,15 +2,10 @@ package org.humanistika.exist.index.algolia
 
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
-
-import cats.effect.{IO, Resource}
-import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
-import cats.syntax.either._
 import javax.xml.parsers.DocumentBuilderFactory
 import org.w3c.dom.{Attr, Document, Element, Node}
 
 import scala.annotation.tailrec
-import scala.util.{Failure, Success}
 
 object DOMHelper {
 
@@ -19,16 +14,9 @@ object DOMHelper {
   def dom(xml: String) : Document = {
     val documentBuilder = documentBuilderFactory.newDocumentBuilder()
 
-    Resource.fromAutoCloseable(IO {new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))}).use { is =>
-      IO {
+    With(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) { is =>
         documentBuilder.parse(is)
-      }
-    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
-      case Right(s) =>
-        s
-      case Left(t) =>
-        throw t
-    }
+    }.get
   }
 
   def attr(node: Node, name: String) : Attr = {

--- a/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
@@ -1,20 +1,13 @@
 package org.humanistika.exist.index.algolia
 
 import DOMHelper._
-import java.io.{ByteArrayInputStream, StringWriter}
-import java.nio.charset.StandardCharsets
+import java.io.StringWriter
 
 import javax.xml.namespace.QName
-import javax.xml.parsers.DocumentBuilderFactory
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.humanistika.exist.index.algolia.Serializer.{serializeElementForAttribute, serializeElementForObject}
 import org.specs2.Specification
-import org.w3c.dom.{Attr, Document, Element, Node}
-import cats.effect.{IO, Resource}
-import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
 import cats.syntax.either._
-
-import scala.util.{Failure, Success}
 
 class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"""
   This is a specification to check the JSON Serialization of IndexableRootObject
@@ -322,18 +315,10 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
   }
 
   private def serializeJson(indexableRootObject: IndexableRootObject): String = {
-    Resource.fromAutoCloseable(IO {new StringWriter()}).use { writer =>
-      IO {
+    With(new StringWriter()) { writer =>
         val mapper = new ObjectMapper
         mapper.writeValue(writer, indexableRootObject)
         writer.toString
-      }
-    }.redeem(_.asLeft, _.asRight)
-      .unsafeRunSync() match {
-      case Right(s) =>
-        s
-      case Left(t) =>
-        throw t
-    }
+    }.get
   }
 }

--- a/src/test/scala/org/humanistika/exist/index/algolia/LocalIndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/LocalIndexableRootObjectJsonSerializerSpec.scala
@@ -8,10 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.specs2.Specification
 import java.nio.charset.StandardCharsets.UTF_8
 
-import cats.effect.{IO, Resource}
-import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
-import cats.syntax.either._
-
 class LocalIndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"""
   This is a specification to check the JSON Serialization of IndexableRootObject
 
@@ -35,30 +31,17 @@ class LocalIndexableRootObjectJsonSerializerSpec extends Specification { def is 
 
   private def createTempJsonFile(json: String) : Path = {
     val p = Files.createTempFile("test", "json")
-    Resource.fromAutoCloseable(IO {Files.newBufferedWriter(p, UTF_8)}).use { writer =>
-      IO {
+    With(Files.newBufferedWriter(p, UTF_8)) { writer =>
         writer.write(json)
-      }
-    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
-      case Right(_) =>
         p
-      case Left(t) =>
-        throw t
-    }
+    }.get
   }
 
   private def serializeJson[T](obj: T): String = {
-    Resource.fromAutoCloseable(IO {new StringWriter}).use { writer =>
-      IO {
+    With(new StringWriter) { writer =>
         val mapper = new ObjectMapper
         mapper.writeValue(writer, obj)
         writer.toString
-      }
-    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
-      case Right(s) =>
-        s
-      case Left(t) =>
-        throw t
-    }
+    }.get
   }
 }

--- a/src/test/scala/org/humanistika/exist/index/algolia/SerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/SerializerSpec.scala
@@ -1,13 +1,8 @@
 package org.humanistika.exist.index.algolia
 
 import Serializer.{serializeElementForAttribute, serializeElementForObject}
-import DOMHelper._
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
-
-import cats.effect.{IO, Resource}
-import cats.effect.unsafe.implicits.global    // TODO(AR) switch to using cats.effect.IOApp
-import cats.syntax.either._
 import javax.xml.parsers.DocumentBuilderFactory
 import org.specs2.Specification
 import org.w3c.dom.{Document, Element, Node}
@@ -84,16 +79,9 @@ class SerializerSpec extends Specification { def is = s2"""
   private lazy val documentBuilderFactory = DocumentBuilderFactory.newInstance()
   private def dom(xml: String) : Document = {
     val documentBuilder = documentBuilderFactory.newDocumentBuilder()
-    Resource.fromAutoCloseable(IO {new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))}).use { is =>
-      IO {
+    With(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) { is =>
         documentBuilder.parse(is)
-      }
-    }.redeem(_.asLeft, _.asRight).unsafeRunSync() match {
-      case Right(s) =>
-        s
-      case Left(t) =>
-        throw t
-    }
+    }.get
   }
 
   private def elem(node: Node, name: String) : Element = {


### PR DESCRIPTION
Cats-effect was only really being used for ARM (Automatic Resource Management), but we can take a simpler approach with our own `With` class in Scala 2.12. If we upgrade later to Scala 2.13, we can use `scala.util.Using` instead.