### PR TITLE
Feature introduce visible by attribute 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For incremental indexing to work, you need to have two sets of unique ids, one f
                     <namespace>http://www.w3.org/XML/1998/namespace</namespace>
                 </namespaceMapping>
             </namespaceMappings>
-            <index name="my-algolia-index-1" documentId="/path/to/unique-id/@хml:id">
+            <index name="my-algolia-index-1" documentId="/path/to/unique-id/@хml:id" visibleBy="/path/to/unique-id">
                 <rootObject path="/path/to/element" nodeId="@xml:id">
                     <attribute name="f1" path="/further/patha"/>
                     <attribute name="f2" path="/further/pathb" type="integer"/>
@@ -87,6 +87,8 @@ For incremental indexing to work, you need to have two sets of unique ids, one f
 ```
 
 
+An Optional `VisibleBy` attribute can be used to restrict data access when searching the Algolia index
+
 A `rootObject` is equivalent to an object inside an Algolia Index. We create one "rootObject" either for each document, or document fragment (if you specify a path attribute on the rootObject).
 
 An `attribute` (represents a JSON object attribute, not to be confused with an XML attribute) is a simple key/value pair that is extracted from the XML and placed into the Algolia object ("rootObject" as we call it). All of the text nodes or attribute values indicated by the "path" on the "attribute" element will be serialized to a string (and then converted if you set an explicit "type" attribute).
@@ -98,6 +100,14 @@ The XML Schema file https://github.com/BCDH/exist-algolia-index/blob/master/src/
 An `object` represents a JSON object, and this is where things become fun, we basically serialize the XML node pointed to by the "path" attribute on the "object" element to a JSON equivalent. This allows you to create highly complex and structured objects in the Algolia index from your XML.
 
 The `name` attribute that is available on the "attribute" and "object" elements allows you to set the name of the field in the JSON object of the Algolia index, this means that name names of your data fields can be different in Algolia to eXist if you wish.
+
+## limiting Objects access to certain users
+You can limit data access by setting the `visibleBy` attribute in `collection.xconf` then matching the path in your XML data preferably in the header
+You can use this example from out test suit
+
+xml: https://github.com/BCDH/exist-algolia-index/tree/master/src/test/resources/integration/user-specified-visibleBy/VSK.TEST.xml
+
+collection.xconf https://github.com/BCDH/exist-algolia-index/tree/master/src/test/resources/integration/user-specified-visibleBy/collection.xconf
 
 <a name="logging"/>
 

--- a/src/main/resources/xsd/exist-algolia-index-config.xsd
+++ b/src/main/resources/xsd/exist-algolia-index-config.xsd
@@ -123,6 +123,11 @@
           <xs:documentation>Indicates an element or attribute to use the value of as a unique id for the document, if ommitted the document's id is used</xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="visibleBy" use="optional" type="c:absoluteElementPathOrAbsoluteAttributePathType">
+        <xs:annotation>
+          <xs:documentation>Sets the rule of who can request the records, if omitted the default value will be public</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializer.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializer.scala
@@ -29,6 +29,7 @@ object IndexableRootObjectJsonSerializer {
   val OBJECT_ID_FIELD_NAME = "objectID"
   val COLLECTION_PATH_FIELD_NAME = "collection"
   val DOCUMENT_ID_FIELD_NAME = "documentID"
+  val RECORD_VISIBLE_BY_FIELD_NAME = "visible_by"
 }
 
 class IndexableRootObjectJsonSerializer extends JsonSerializer[IndexableRootObject] {
@@ -46,6 +47,11 @@ class IndexableRootObjectJsonSerializer extends JsonSerializer[IndexableRootObje
         gen.writeStringField(DOCUMENT_ID_FIELD_NAME, usd)
       case None =>
         gen.writeNumberField(DOCUMENT_ID_FIELD_NAME, value.documentId)
+    }
+    value.userSpecifiedVisibleBy match {
+      case Some(usv) =>
+        gen.writeStringField(RECORD_VISIBLE_BY_FIELD_NAME, usv)
+      case None => // do nothing
     }
 
     serializeChildren(value.children, gen, serializers)

--- a/src/main/scala/org/humanistika/exist/index/algolia/backend/AlgoliaIndexManagerActor.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/backend/AlgoliaIndexManagerActor.scala
@@ -59,7 +59,7 @@ class AlgoliaIndexManagerActor extends Actor {
       val indexActor = getOrCreatePerIndexActor(indexName)
       indexActor ! changes
 
-    case rfd @ RemoveForDocument(indexName, documentId, userSpecifiedDocumentId) =>
+    case rfd @ RemoveForDocument(indexName, documentId, userSpecifiedDocumentId, userSpecifiedVisibleBy) =>
       if(logger.isTraceEnabled) {
         logger.trace(s"Initiating RemoveForDocument (id=${documentId}, userSpecificDocId=${userSpecifiedDocumentId}) for index: $indexName")
       }
@@ -199,7 +199,7 @@ class AlgoliaIndexActor(indexName: IndexName, algoliaIndex: Index[IndexableRootO
 
 
 
-    case RemoveForDocument(_, documentId, userSpecifiedDocumentId) =>
+    case RemoveForDocument(_, documentId, userSpecifiedDocumentId, userSpecifiedVisibleBy) =>
       val batchLogMsgGroupId: BatchLogMsgGroupId = System.nanoTime()
 
       logger.info(s"Sending remove document (msgId=$batchLogMsgGroupId) to Algolia for documentId=$documentId, userSpecificDocId=$userSpecifiedDocumentId in index: $indexName")

--- a/src/main/scala/org/humanistika/exist/index/algolia/backend/IncrementalIndexingManagerActor.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/backend/IncrementalIndexingManagerActor.scala
@@ -33,7 +33,7 @@ object IncrementalIndexingManagerActor {
   case class Add(indexName: IndexName, indexableRootObject: IndexableRootObject)
   case class FinishDocument(indexName: IndexName, userSpecifiedDocumentId: Option[String], collectionId: CollectionId, documentId: DocumentId)
   case class IndexChanges(indexName: IndexName, changes: Changes)
-  case class RemoveForDocument(indexName: IndexName, documentId: DocumentId, userSpecifiedDocumentId: Option[String])
+  case class RemoveForDocument(indexName: IndexName, documentId: DocumentId, userSpecifiedDocumentId: Option[String], userSpecifiedVisibleBy: Option[String])
   case class RemoveForCollection(indexName: IndexName, collectionPath: String)
   case object DropIndexes
 }

--- a/src/main/scala/org/humanistika/exist/index/algolia/backend/IndexLocalStoreManagerActor.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/backend/IndexLocalStoreManagerActor.scala
@@ -84,7 +84,7 @@ class IndexLocalStoreManagerActor(dataDir: Path) extends Actor {
     case indexChanges : IndexChanges =>
       context.parent ! indexChanges
 
-    case removeForDocument @ RemoveForDocument(indexName, _, _) =>
+    case removeForDocument @ RemoveForDocument(indexName, _, _, _) =>
       val indexActor = getOrCreatePerIndexActor(indexName)
       indexActor ! removeForDocument
 
@@ -131,7 +131,7 @@ class IndexLocalStoreActor(indexesDir: Path, indexName: String) extends Actor {
       this.processing = processing + (documentId -> timestamp)
       getOrCreatePerDocumentActor(documentId)
 
-    case Add(_, iro @ IndexableRootObject(_, _, documentId, _, _, _, _)) =>
+    case Add(_, iro @ IndexableRootObject(_, _, documentId, _, _, _, _, _)) =>
       val perDocumentActor = getOrCreatePerDocumentActor(documentId)
       val timestamp = processing(documentId)
       perDocumentActor ! Write(timestamp, iro)
@@ -152,7 +152,7 @@ class IndexLocalStoreActor(indexesDir: Path, indexName: String) extends Actor {
       context.parent ! IndexChanges(indexName, changes)
     //TODO(AR) when to delete previous timestamp (after upload into Algolia)
 
-    case RemoveForDocument(_, documentId, userSpecifiedDocumentId) =>
+    case RemoveForDocument(_, documentId, userSpecifiedDocumentId, userSpecifiedVisibleBy) =>
       val perDocumentActor = getOrCreatePerDocumentActor(documentId)
       val maybeTimestamp = processing.get(documentId)
       perDocumentActor ! RemoveDocument(documentId, userSpecifiedDocumentId, maybeTimestamp)  // perDocumentActor will stop itself!

--- a/src/main/scala/org/humanistika/exist/index/algolia/package.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/package.scala
@@ -47,6 +47,7 @@ package object algolia {
   }
 
   type UserSpecifiedDocumentId = String
+  type UserSpecifiedVisibleBy = String
   type UserSpecifiedNodeId = String
 
   type CollectionPath = String
@@ -54,7 +55,7 @@ package object algolia {
   type DocumentId = Int
   type objectID = String
 
-  @JsonSerialize(using=classOf[IndexableRootObjectJsonSerializer]) case class IndexableRootObject(collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[Either[IndexableAttribute, IndexableObject]])
+  @JsonSerialize(using=classOf[IndexableRootObjectJsonSerializer]) case class IndexableRootObject(collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], userSpecifiedVisibleBy: Option[UserSpecifiedVisibleBy], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[Either[IndexableAttribute, IndexableObject]])
   case class IndexableAttribute(name: Name, values: IndexableValues, literalType: LiteralTypeConfig.LiteralTypeConfig)
   case class IndexableObject(name: Name, values: IndexableValues)
 

--- a/src/test/resources/integration/user-specified-visibleBy/VSK.TEST.xml
+++ b/src/test/resources/integration/user-specified-visibleBy/VSK.TEST.xml
@@ -1,0 +1,99 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:r="http://raskovnik.org">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Title</title>
+            </titleStmt>
+            <publicationStmt>
+                <p>Publication Information</p>
+            </publicationStmt>
+            <sourceDesc>
+                <p>Information about the source</p>
+            </sourceDesc>
+        </fileDesc>
+        <xenoData>
+            <r:visibleBy>visibility</r:visibleBy>
+        </xenoData>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:id="VSK.SR.letter.а" xml:base="VSK.SR.letter.%D0%B0.xml">
+                <entryFree xml:id="VSK.SR.Adam">
+                    <form type="lemma">
+                        <orth>Adam</orth>
+                    </form>
+                    <pc>,</pc>
+                    <gramGrp>
+                        <pos>m</pos>
+                    </gramGrp>
+                    <sense xml:id="d1e403">
+                        <cit type="tr">
+                            <quote>Адам</quote>
+                        </cit>
+                        <pc>.</pc>
+                    </sense>
+                </entryFree>
+                <entryFree xml:id="VSK.SR.Addam">
+                    <form type="lemma">
+                        <orth>Addam</orth>
+                    </form>
+                    <pc>,</pc>
+                    <gramGrp>
+                        <pos>m</pos>
+                    </gramGrp>
+                    <sense xml:id="d1e404">
+                        <cit type="tr">
+                            <quote>Аддам</quote>
+                        </cit>
+                        <pc>.</pc>
+                    </sense>
+                </entryFree>
+                <entryFree xml:id="VSK.SR.Adamm">
+                    <form type="lemma">
+                        <orth>Adamm</orth>
+                    </form>
+                    <pc>,</pc>
+                    <gramGrp>
+                        <pos>m</pos>
+                    </gramGrp>
+                    <sense xml:id="d1e4043">
+                        <cit type="tr">
+                            <quote>Адамм</quote>
+                        </cit>
+                        <pc>.</pc>
+                    </sense>
+                </entryFree>
+                <entryFree xml:id="VSK.SR.Adammm">
+                    <form type="lemma">
+                        <orth>Adammm</orth>
+                    </form>
+                    <pc/>
+                    <gramGrp>
+                        <pos>m</pos>
+                    </gramGrp>
+                    <sense xml:id="d1e40443">
+                        <cit type="tr">
+                            <quote>Адаммм</quote>
+                        </cit>
+                        <pc>.</pc>
+                    </sense>
+                </entryFree>
+                <entryFree xml:id="VSK.SR.Adammmm">
+                    <form type="lemma">
+                        <orth>Adammmmm</orth>
+                    </form>
+                    <pc/>
+                    <gramGrp>
+                        <pos>m.</pos>
+                    </gramGrp>
+                    <sense xml:id="d1e404443">
+                        <cit type="tr">
+                            <quote>Адамммм</quote>
+                        </cit>
+                        <pc>.</pc>
+                    </sense>
+                </entryFree>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/src/test/resources/integration/user-specified-visibleBy/collection.xconf
+++ b/src/test/resources/integration/user-specified-visibleBy/collection.xconf
@@ -1,0 +1,27 @@
+<collection xmlns="http://exist-db.org/collection-config/1.0">
+    <index xmlns:r="http://raskovnik.org" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <algolia>
+            <namespaceMappings>
+                <namespaceMapping>
+                    <prefix>tei</prefix>
+                    <namespace>http://www.tei-c.org/ns/1.0</namespace>
+                </namespaceMapping>
+                <namespaceMapping>
+                    <prefix>xml</prefix>
+                    <namespace>http://www.w3.org/XML/1998/namespace</namespace>
+                </namespaceMapping>
+                <namespaceMapping>
+                    <prefix>r</prefix>
+                    <namespace>http://raskovnik.org</namespace>
+                </namespaceMapping>
+            </namespaceMappings>
+            <index name="raskovnik-test-integration-user-visibleBy" visibleBy="/tei:TEI/tei:teiHeader/tei:xenoData/r:visibleBy">
+                <rootObject path="/tei:TEI/tei:text/tei:body/tei:div/tei:entryFree">
+                    <attribute name="lemma" path="/tei:form/tei:orth"/>
+                    <attribute name="dict" path="@xml:id"/>
+                    <attribute name="tr" path="/tei:sense/tei:cit/tei:quote"/>
+                </rootObject>
+            </index>
+        </algolia>
+    </index>
+</collection>

--- a/src/test/scala/org/humanistika/exist/index/algolia/AlgoliaStreamListenerIntegrationSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/AlgoliaStreamListenerIntegrationSpec.scala
@@ -56,23 +56,23 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.4"), None, Seq(
         Left(("dict", Seq("1.5.2.2.4.1"))),
         Left(("lemma", Seq("1.5.2.2.4.3.3"))),
         Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.6"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.6"), None, Seq(
         Left(("dict", Seq("1.5.2.2.6.1"))),
         Left(("lemma", Seq("1.5.2.2.6.3.3"))),
         Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.8"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.8"), None, Seq(
         Left(("dict", Seq("1.5.2.2.8.1"))),
         Left(("lemma", Seq("1.5.2.2.8.3.3"))),
         Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.10"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.10"), None, Seq(
         Left(("dict", Seq("1.5.2.2.10.1"))),
         Left(("lemma", Seq("1.5.2.2.10.3.3"))),
         Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.12"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.12"), None, Seq(
         Left(("dict", Seq("1.5.2.2.12.1"))),
         Left(("lemma", Seq("1.5.2.2.12.3.3"))),
         Left(("tr", Seq("1.5.2.2.12.9.3.3")))))
@@ -103,12 +103,12 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.4"), None, Seq(
         Left(("lemma", Seq(
           "1.5.2.2.4.6.3",
           "1.5.2.2.4.8.5",
           "1.5.2.2.4.12.5")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.6"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.6"), None, Seq(
         Left(("lemma", Seq(
           "1.5.2.2.6.6.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
@@ -138,23 +138,23 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.4"), None, Seq(
         Left(("dict", Seq("1.5.2.2.4.1"))),
         Left(("lemma", Seq("1.5.2.2.4.3.3"))),
         Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.6"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.6"), None, Seq(
         Left(("dict", Seq("1.5.2.2.6.1"))),
         Left(("lemma", Seq("1.5.2.2.6.3.3"))),
         Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.8"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.8"), None, Seq(
         Left(("dict", Seq("1.5.2.2.8.1"))),
         Left(("lemma", Seq("1.5.2.2.8.3.3"))),
         Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.10"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.10"), None, Seq(
         Left(("dict", Seq("1.5.2.2.10.1"))),
         Left(("inverse-lemma", Seq("1.5.2.2.10.3.3"))),
         Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.12"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.12"), None, Seq(
         Left(("dict", Seq("1.5.2.2.12.1"))),
         Left(("lemma", Seq("1.5.2.2.12.3.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
@@ -183,7 +183,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some("1.5.2.2.4"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, None, Some("1.5.2.2.4"), None, Seq(
         Left(("trde", Seq("1.5.2.2.4.14.6.3", "1.5.2.2.4.16.6.3", "1.5.2.2.4.18.6.3", "1.5.2.2.4.18.8.3", "1.5.2.2.4.22.6.3", "1.5.2.2.4.24.8.3", "1.5.2.2.4.26.6.3"))),
         Left(("trla", Seq("1.5.2.2.4.14.8.3", "1.5.2.2.4.14.10.5", "1.5.2.2.4.16.8.3", "1.5.2.2.4.18.10.3", "1.5.2.2.4.18.12.3", "1.5.2.2.4.22.8.3", "1.5.2.2.4.24.10.3", "1.5.2.2.4.26.8.3")))))
       expectMsg(FinishDocument(indexName, None, collectionId, docId))
@@ -214,27 +214,73 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.4"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.4"), None, Seq(
         Left(("dict", Seq("1.5.2.2.4.1"))),
         Left(("lemma", Seq("1.5.2.2.4.3.3"))),
         Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.6"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.6"), None, Seq(
         Left(("dict", Seq("1.5.2.2.6.1"))),
         Left(("lemma", Seq("1.5.2.2.6.3.3"))),
         Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.8"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.8"), None, Seq(
         Left(("dict", Seq("1.5.2.2.8.1"))),
         Left(("lemma", Seq("1.5.2.2.8.3.3"))),
         Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.10"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.10"), None, Seq(
         Left(("dict", Seq("1.5.2.2.10.1"))),
         Left(("lemma", Seq("1.5.2.2.10.3.3"))),
         Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.12"), None, Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.12"), None, Seq(
         Left(("dict", Seq("1.5.2.2.12.1"))),
         Left(("lemma", Seq("1.5.2.2.12.3.3"))),
         Left(("tr", Seq("1.5.2.2.12.9.3.3")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
+    }
+
+    "produce the correct actor messages for a basic index config with user visibleBy" in new AkkaTestkitSpecs2Support {
+
+      val indexName = "raskovnik-test-integration-user-visibleBy"
+      val userSpecifiedvisibleBy = "visibility"
+      val testCollectionPath = XmldbURI.create("/db/test-integration-user-visibleBy")
+
+      // register our index
+      implicit val brokerPool: BrokerPool = getBrokerPool
+      val algoliaIndex = createAndRegisterAlgoliaIndex(system, Some(testActor))
+
+      // set up an index configuration
+      storeCollectionConfig(algoliaIndex, testCollectionPath, getTestResource("integration/user-specified-visibleBy/collection.xconf"))
+
+      // store some data (which will be indexed)
+      val (collectionId, docId) = storeTestDocument(algoliaIndex, testCollectionPath, getTestResource("integration/user-specified-visibleBy/VSK.TEST.xml"))
+
+      collectionId mustNotEqual -1
+      docId mustNotEqual -1
+
+      val collectionPath = testCollectionPath.getRawCollectionPath
+
+      expectMsg(Authentication("some-application-id", "some-admin-api-key"))
+      expectMsg(StartDocument(indexName, collectionId, docId))
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some(userSpecifiedvisibleBy), Some("1.4.2.2.4"), None, Seq(
+        Left(("dict", Seq("1.4.2.2.4.1"))),
+        Left(("lemma", Seq("1.4.2.2.4.3.3"))),
+        Left(("tr", Seq("1.4.2.2.4.9.3.3")))))
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some(userSpecifiedvisibleBy), Some("1.4.2.2.6"), None, Seq(
+        Left(("dict", Seq("1.4.2.2.6.1"))),
+        Left(("lemma", Seq("1.4.2.2.6.3.3"))),
+        Left(("tr", Seq("1.4.2.2.6.9.3.3")))))
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some(userSpecifiedvisibleBy), Some("1.4.2.2.8"), None, Seq(
+        Left(("dict", Seq("1.4.2.2.8.1"))),
+        Left(("lemma", Seq("1.4.2.2.8.3.3"))),
+        Left(("tr", Seq("1.4.2.2.8.9.3.3")))))
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some(userSpecifiedvisibleBy), Some("1.4.2.2.10"), None, Seq(
+        Left(("dict", Seq("1.4.2.2.10.1"))),
+        Left(("lemma", Seq("1.4.2.2.10.3.3"))),
+        Left(("tr", Seq("1.4.2.2.10.9.3.3")))))
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, None, Some(userSpecifiedvisibleBy), Some("1.4.2.2.12"), None, Seq(
+        Left(("dict", Seq("1.4.2.2.12.1"))),
+        Left(("lemma", Seq("1.4.2.2.12.3.3"))),
+        Left(("tr", Seq("1.4.2.2.12.9.3.3")))))
+      expectMsg(FinishDocument(indexName, None, collectionId, docId))
     }
 
 
@@ -262,23 +308,23 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.4"), Some("VSK.SR.Adam"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.4"), Some("VSK.SR.Adam"), Seq(
         Left(("dict", Seq("1.5.2.2.4.1"))),
         Left(("lemma", Seq("1.5.2.2.4.3.3"))),
         Left(("tr", Seq("1.5.2.2.4.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.6"), Some("VSK.SR.Addam"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.6"), Some("VSK.SR.Addam"), Seq(
         Left(("dict", Seq("1.5.2.2.6.1"))),
         Left(("lemma", Seq("1.5.2.2.6.3.3"))),
         Left(("tr", Seq("1.5.2.2.6.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.8"), Some("VSK.SR.Adamm"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.8"), Some("VSK.SR.Adamm"), Seq(
         Left(("dict", Seq("1.5.2.2.8.1"))),
         Left(("lemma", Seq("1.5.2.2.8.3.3"))),
         Left(("tr", Seq("1.5.2.2.8.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.10"), Some("VSK.SR.Adammm"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.10"), Some("VSK.SR.Adammm"), Seq(
         Left(("dict", Seq("1.5.2.2.10.1"))),
         Left(("lemma", Seq("1.5.2.2.10.3.3"))),
         Left(("tr", Seq("1.5.2.2.10.9.3.3")))))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("1.5.2.2.12"), Some("VSK.SR.Adammmm"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("1.5.2.2.12"), Some("VSK.SR.Adammmm"), Seq(
         Left(("dict", Seq("1.5.2.2.12.1"))),
         Left(("lemma", Seq("1.5.2.2.12.3.3"))),
         Left(("tr", Seq("1.5.2.2.12.9.3.3")))))
@@ -309,7 +355,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
         Right(("e-e", Seq("4.6.2.2.4.7")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
@@ -338,7 +384,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
         Right(("e-e", Seq("4.6.2.2.4.7")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
@@ -367,7 +413,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("4.6.2.2.4"), Some("MZ.RGJS.наводаџија"), Seq(
         Right(("e-e", Seq("4.6.2.2.4.7")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
@@ -396,7 +442,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("3.5.2.2.4"), Some("VSK.SR.баба2"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("3.5.2.2.4"), Some("VSK.SR.баба2"), Seq(
         Right(("e-e", Seq("3.5.2.2.4.8", "3.5.2.2.4.10", "3.5.2.2.4.12", "3.5.2.2.4.14")))))
       expectMsg(FinishDocument(indexName, Some(userSpecifiedDocId), collectionId, docId))
     }
@@ -425,7 +471,7 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
 
       expectMsg(Authentication("some-application-id", "some-admin-api-key"))
       expectMsg(StartDocument(indexName, collectionId, docId))
-      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), Some("4.6.2.2.4"), Some("VSK.SR.џукела"), Seq(
+      assertAdd(expectMsgType[Add])(indexName, collectionPath, collectionId, docId, Some(userSpecifiedDocId), None, Some("4.6.2.2.4"), Some("VSK.SR.џукела"), Seq(
         Left(("l", Seq("4.6.2.2.4.4.3"))),
         Left(("t-de", Seq("4.6.2.2.4.8.3.3"))),
         Left(("t-la", Seq("4.6.2.2.4.8.5.3")))))
@@ -439,12 +485,13 @@ class AlgoliaStreamListenerIntegrationSpec extends Specification with ExistServe
   type IndexableAttributeNameAndValueIds = NameAndValueIds
   type IndexableObjectNameAndValueIds = NameAndValueIds
 
-  private def assertAdd(addMsg: Add)(indexName: IndexName, collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[Either[IndexableAttributeNameAndValueIds, IndexableObjectNameAndValueIds]]) = {
+  private def assertAdd(addMsg: Add)(indexName: IndexName, collectionPath: CollectionPath, collectionId: CollectionId, documentId: DocumentId, userSpecifiedDocumentId: Option[UserSpecifiedDocumentId], userSpecifiedVisibleBy: Option[UserSpecifiedVisibleBy] , nodeId: Option[String], userSpecifiedNodeId: Option[UserSpecifiedNodeId], children: Seq[Either[IndexableAttributeNameAndValueIds, IndexableObjectNameAndValueIds]]) = {
     addMsg.indexName mustEqual indexName
     addMsg.indexableRootObject.collectionPath mustEqual collectionPath
     addMsg.indexableRootObject.collectionId mustEqual collectionId
     addMsg.indexableRootObject.documentId mustEqual documentId
     addMsg.indexableRootObject.userSpecifiedDocumentId mustEqual userSpecifiedDocumentId
+    addMsg.indexableRootObject.userSpecifiedVisibleBy mustEqual userSpecifiedVisibleBy
     addMsg.indexableRootObject.nodeId mustEqual nodeId
     addMsg.indexableRootObject.userSpecifiedNodeId mustEqual userSpecifiedNodeId
 

--- a/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/IndexableRootObjectJsonSerializerSpec.scala
@@ -19,99 +19,105 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
       prefer the user specified document id $e2
       have a nodeId (if provided) $e3
       prefer the user specified node id $e4
+      have a visibleBy (if provided) $e5
 
     The JSON serialized result attributes for DOM Attributes must
-      be constructable $e5
-      be float convertible $e6
-      be int convertible $e7
-      be boolean convertible $e8
-      allow multiple $e9
-      support arrays $e10
+      be constructable $e6
+      be float convertible $e7
+      be int convertible $e8
+      be boolean convertible $e9
+      allow multiple $e10
+      support arrays $e11
 
     The JSON serialized result attributes for DOM Elements must
-      be constructable $e11
-      be float convertible $e12
-      be int convertible $e13
-      be boolean convertible $e14
-      allow multiple $e15
-      serialize all text nodes $e16
-      serialize all text nodes and not attributes $e17
-      support arrays $e18
-      support arrays (of text nodes and not attributes) $e19
-      be valid when only child text nodes are provided $e20
+      be constructable $e12
+      be float convertible $e13
+      be int convertible $e14
+      be boolean convertible $e15
+      allow multiple $e16
+      serialize all text nodes $e17
+      serialize all text nodes and not attributes $e18
+      support arrays $e19
+      support arrays (of text nodes and not attributes) $e20
+      be valid when only child text nodes are provided $e21
 
     The JSON serialized result objects for DOM Attributes must
-      be the same as a result attribute $e21
-      support arrays $e22
+      be the same as a result attribute $e22
+      support arrays $e23
 
     The JSON serialized result objects for DOM Elements must
-      be constructable $e23
-      write nested elements $e24
-      write array $e25
-      write nested array $e26
-      support arrays $e27
-      be valid when only child text nodes are provided $e28
-      be valid when only attributes are provided $e29
-      be valid when only child text nodes and attributes are provided $e30
+      be constructable $e24
+      write nested elements $e25
+      write array $e26
+      write nested array $e27
+      support arrays $e28
+      be valid when only child text nodes are provided $e29
+      be valid when only attributes are provided $e30
+      be valid when only child text nodes and attributes are provided $e31
 """
 
   def e1 = {
-    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, None, None, None, Seq.empty)
+    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, None, None, None, None, Seq.empty)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"5/46/0","collection":"/db/a1","documentID":46}"""
   }
 
   def e2 = {
-    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, Some("my-document-id"), None, None, Seq.empty)
+    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, Some("my-document-id"), None, None, None, Seq.empty)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"5/46/0","collection":"/db/a1","documentID":"my-document-id"}"""
   }
 
   def e3 = {
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 47, None, Some("1.2.2"), None, Seq.empty)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 47, None, None,Some("1.2.2"), None, Seq.empty)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/47/1.2.2","collection":"/db/a1","documentID":47}"""
   }
 
   def e4 = {
-    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, None, None, Some("my-node-id"), Seq.empty)
+    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, None, None, None, Some("my-node-id"), Seq.empty)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"my-node-id","collection":"/db/a1","documentID":46}"""
   }
 
   def e5 = {
-    val attr1_kv = new AttributeKV(new QName("value"), "hello")
-    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.String)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, Some("1"), None, attributes)
-    serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"attr1":"hello"}"""
+    val indexableRootObject = IndexableRootObject("/db/a1", 5, 46, None, Some("visibility"), None, None, Seq.empty)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"5/46/0","collection":"/db/a1","documentID":46,"visible_by":"visibility"}"""
   }
 
   def e6 = {
-    val attr1_kv = new AttributeKV(new QName("value"), "99.9")
-    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Float)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 2, 49, None, Some("1"), None, attributes)
-    serializeJson(indexableRootObject) mustEqual """{"objectID":"2/49/1","collection":"/db/a1","documentID":49,"attr1":99.9}"""
+    val attr1_kv = new AttributeKV(new QName("value"), "hello")
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.String)))
+    val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, None, Some("1"), None, attributes)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"attr1":"hello"}"""
   }
 
   def e7 = {
-    val attr1_kv = new AttributeKV(new QName("value"), "1012")
-    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Integer)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 9, 50, None, Some("1"), None, attributes)
-    serializeJson(indexableRootObject) mustEqual """{"objectID":"9/50/1","collection":"/db/a1","documentID":50,"attr1":1012}"""
+    val attr1_kv = new AttributeKV(new QName("value"), "99.9")
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Float)))
+    val indexableRootObject = IndexableRootObject("/db/a1", 2, 49, None, None, Some("1"), None, attributes)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"2/49/1","collection":"/db/a1","documentID":49,"attr1":99.9}"""
   }
 
   def e8 = {
-    val attr1_kv = new AttributeKV(new QName("value"), "true")
-    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Boolean)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 3, 51, None, Some("1"), None, attributes)
-    serializeJson(indexableRootObject) mustEqual """{"objectID":"3/51/1","collection":"/db/a1","documentID":51,"attr1":true}"""
+    val attr1_kv = new AttributeKV(new QName("value"), "1012")
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Integer)))
+    val indexableRootObject = IndexableRootObject("/db/a1", 9, 50, None, None, Some("1"), None, attributes)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"9/50/1","collection":"/db/a1","documentID":50,"attr1":1012}"""
   }
 
   def e9 = {
-    val attr1_kv = new AttributeKV(new QName("x"), "99.9")
-    val attr2_kv = new AttributeKV(new QName("y"), "11.4")
-    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Float)), Left(IndexableAttribute("attr2", Seq(IndexableValue("1.2", Right(attr2_kv))), LiteralTypeConfig.Float)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 3, 52, None, Some("1"), None, attributes)
-    serializeJson(indexableRootObject) mustEqual """{"objectID":"3/52/1","collection":"/db/a1","documentID":52,"attr1":99.9,"attr2":11.4}"""
+    val attr1_kv = new AttributeKV(new QName("value"), "true")
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Boolean)))
+    val indexableRootObject = IndexableRootObject("/db/a1", 3, 51, None, None, Some("1"), None, attributes)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"3/51/1","collection":"/db/a1","documentID":51,"attr1":true}"""
   }
 
   def e10 = {
+    val attr1_kv = new AttributeKV(new QName("x"), "99.9")
+    val attr2_kv = new AttributeKV(new QName("y"), "11.4")
+    val attributes = Seq(Left(IndexableAttribute("attr1", Seq(IndexableValue("1.1", Right(attr1_kv))), LiteralTypeConfig.Float)), Left(IndexableAttribute("attr2", Seq(IndexableValue("1.2", Right(attr2_kv))), LiteralTypeConfig.Float)))
+    val indexableRootObject = IndexableRootObject("/db/a1", 3, 52, None, None, Some("1"), None, attributes)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"3/52/1","collection":"/db/a1","documentID":52,"attr1":99.9,"attr2":11.4}"""
+  }
+
+  def e11 = {
     val attr1_1_kv = new AttributeKV(new QName("x"), "99.9")
     val attr1_2_kv = new AttributeKV(new QName("x"), "202.2")
     val attr2_1_kv = new AttributeKV(new QName("y"), "11.4")
@@ -120,62 +126,62 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
       Left(IndexableAttribute("xx", Seq(IndexableValue("1.1", Right(attr1_1_kv)), IndexableValue("2.1", Right(attr1_2_kv))), LiteralTypeConfig.Float)),
       Left(IndexableAttribute("yy", Seq(IndexableValue("1.2", Right(attr2_1_kv)), IndexableValue("2.2", Right(attr2_2_kv))), LiteralTypeConfig.Float))
     )
-    val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/42/1","collection":"/db/a1","documentID":42,"xx":[99.9,202.2],"yy":[11.4,10.2]}"""
   }
 
-  def e11 = {
+  def e12 = {
     val elem1_kv = new ElementKV(new QName("w"), "hello")
     val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 48, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 48, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/48/1","collection":"/db/a1","documentID":48,"elem1":"hello"}"""
   }
 
-  def e12 = {
+  def e13 = {
     val elem1_kv = new ElementKV(new QName("x"), "99.9")
     val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Float)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"elem1":99.9}"""
   }
 
-  def e13 = {
+  def e14 = {
     val elem1_kv = new ElementKV(new QName("y"), "1012")
     val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Integer)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 2, 48, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 2, 48, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"2/48/1","collection":"/db/a1","documentID":48,"elem1":1012}"""
   }
 
-  def e14 = {
+  def e15 = {
     val elem1_kv = new ElementKV(new QName("z"), "true")
     val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Boolean)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 1, 48, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 1, 48, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"1/48/1","collection":"/db/a1","documentID":48,"elem1":true}"""
   }
 
-  def e15 = {
+  def e16 = {
     val elem1_kv = new ElementKV(new QName("x"), "99.9")
     val elem2_kv = new ElementKV(new QName("y"), "11.3")
     val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.Float)), Left(IndexableAttribute("elem2", Seq(IndexableValue("1.2", Left(elem2_kv))), LiteralTypeConfig.Float)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 7, 48, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/48/1","collection":"/db/a1","documentID":48,"elem1":99.9,"elem2":11.3}"""
   }
 
-  def e16 = {
+  def e17 = {
     val elem1_kv = new ElementKV(new QName("x"), "hello world")
     val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 23, 48, None, Some("1"), None, attributes)
-    serializeJson(indexableRootObject) mustEqual """{"objectID":"23/48/1","collection":"/db/a1","documentID":48,"elem1":"hello world"}"""
-  }
-
-  def e17 = {
-    val elem1 = elem(dom("""<x y="17">hello <b>world</b></x>"""), "x")
-    val elem1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(elem1).valueOr(ts => throw ts.head))
-    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
-    val indexableRootObject = IndexableRootObject("/db/a1", 23, 48, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 23, 48, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"23/48/1","collection":"/db/a1","documentID":48,"elem1":"hello world"}"""
   }
 
   def e18 = {
+    val elem1 = elem(dom("""<x y="17">hello <b>world</b></x>"""), "x")
+    val elem1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(elem1).valueOr(ts => throw ts.head))
+    val attributes = Seq(Left(IndexableAttribute("elem1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String)))
+    val indexableRootObject = IndexableRootObject("/db/a1", 23, 48, None, None, Some("1"), None, attributes)
+    serializeJson(indexableRootObject) mustEqual """{"objectID":"23/48/1","collection":"/db/a1","documentID":48,"elem1":"hello world"}"""
+  }
+
+  def e19 = {
     val dom1 = dom("""<loc><pos><x>123.4</x><y>-17.45</y></pos><pos><x>456.12</x><y>15.67</y></pos></loc>""")
     val pos = elems(dom1, "pos")
     val elem1_1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(childElem(pos(0), "x")).valueOr(ts => throw ts.head))
@@ -186,11 +192,11 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
       Left(IndexableAttribute("xx", Seq(IndexableValue("1.1", Left(elem1_1_kv)), IndexableValue("2.1", Left(elem1_2_kv))), LiteralTypeConfig.Float)),
       Left(IndexableAttribute("yy", Seq(IndexableValue("1.2", Left(elem2_1_kv)), IndexableValue("2.2", Left(elem2_2_kv))), LiteralTypeConfig.Float))
     )
-    val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/42/1","collection":"/db/a1","documentID":42,"xx":[123.4,456.12],"yy":[-17.45,15.67]}"""
   }
 
-  def e19 = {
+  def e20 = {
     val dom1 = dom("""<loc><pos><x a="1">123.4</x><y b="2">-17.45</y></pos><pos><x a="8">456.12</x><y b="9">15.67</y></pos></loc>""")
     val pos = elems(dom1, "pos")
     val elem1_1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(childElem(pos(0), "x")).valueOr(ts => throw ts.head))
@@ -201,73 +207,73 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
       Left(IndexableAttribute("xx", Seq(IndexableValue("1.1", Left(elem1_1_kv)), IndexableValue("2.1", Left(elem1_2_kv))), LiteralTypeConfig.Float)),
       Left(IndexableAttribute("yy", Seq(IndexableValue("1.2", Left(elem2_1_kv)), IndexableValue("2.2", Left(elem2_2_kv))), LiteralTypeConfig.Float))
     )
-    val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 7, 42, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"7/42/1","collection":"/db/a1","documentID":42,"xx":[123.4,456.12],"yy":[-17.45,15.67]}"""
   }
 
-  def e20 = {
+  def e21 = {
     val dom1 = dom("""<parts><w><x>hello</x></w></parts>""")
     val elem1 = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForAttribute(elem1).valueOr(ts => throw ts.head))
     val attributes = Seq(
       Left(IndexableAttribute("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))), LiteralTypeConfig.String))
     )
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, attributes)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, None, Some("1"), None, attributes)
     serializeJson(indexableRootObject) mustEqual
       """{"objectID":"6/53/1","collection":"/db/a1","documentID":53,"obj1":"hello"}""".stripMargin
   }
 
-  def e21 = {
+  def e22 = {
     val attr1_kv = new AttributeKV(new QName("value"), "hello")
     val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Right(attr1_kv))))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 45, 48, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 45, 48, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"45/48/1","collection":"/db/a1","documentID":48,"obj1":"hello"}"""
   }
 
-  def e22 = {
+  def e23 = {
     val attr1_1_kv = new AttributeKV(new QName("value"), "hello")
     val attr1_2_kv = new AttributeKV(new QName("value"), "world")
     val objects = Seq(Right(IndexableObject("obj1", Seq(
       IndexableValue("1.1.1", Right(attr1_1_kv)),
       IndexableValue("1.2.1", Right(attr1_2_kv))
     ))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 46, 49, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 46, 49, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"46/49/1","collection":"/db/a1","documentID":49,"obj1":["hello","world"]}"""
   }
 
-  def e23 = {
+  def e24 = {
     val elem1 = elem(dom("""<w><x>hello</x><y>world</y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 5, 48, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 5, 48, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"5/48/1","collection":"/db/a1","documentID":48,"obj1":{"nodeId":"1.1","x":"hello","y":"world"}}"""
   }
 
-  def e24 = {
+  def e25 = {
     val elem1 = elem(dom("""<w><x>hello</x><y><z>world</z><zz>again</zz></y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 2, 49, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 2, 49, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"2/49/1","collection":"/db/a1","documentID":49,"obj1":{"nodeId":"1.1","x":"hello","y":{"z":"world","zz":"again"}}}"""
   }
 
-  def e25 = {
+  def e26 = {
     val elem1 = elem(dom("""<w><x>hello</x><y>world</y><y>again</y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 3, 50, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 3, 50, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"3/50/1","collection":"/db/a1","documentID":50,"obj1":{"nodeId":"1.1","x":"hello","y":["world","again"]}}"""
   }
 
-  def e26 = {
+  def e27 = {
     val elem1 = elem(dom("""<w><x>hello</x><y><yy>world</yy><yy>again</yy></y></w>"""), "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(IndexableValue("1.1", Left(elem1_kv))))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 51, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 51, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/51/1","collection":"/db/a1","documentID":51,"obj1":{"nodeId":"1.1","x":"hello","y":{"yy":["world","again"]}}}"""
   }
 
-  def e27 = {
+  def e28 = {
     val dom1 = dom("""<parts><w><x>hello</x><y><yy>world</yy><yy>again</yy></y></w><w><x>goodbye</x><y><yy>until</yy><yy>next time</yy></y></w></parts>""")
     val ww = elems(dom1, "w")
     val elem1_kv = new ElementKV(new QName("w"), serializeElementForObject("obj1", Map.empty, Map.empty)(ww(0)).valueOr(ts => throw ts.head))
@@ -276,51 +282,51 @@ class IndexableRootObjectJsonSerializerSpec extends Specification { def is = s2"
       IndexableValue("1.1", Left(elem1_kv)),
       IndexableValue("1.2", Left(elem2_kv))
     ))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 52, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 52, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual """{"objectID":"6/52/1","collection":"/db/a1","documentID":52,"obj1":[{"nodeId":"1.1","x":"hello","y":{"yy":["world","again"]}},{"nodeId":"1.2","x":"goodbye","y":{"yy":["until","next time"]}}]}"""
   }
 
-  def e28 = {
+  def e29 = {
     val dom1 = dom("""<parts><w><x>hello</x></w></parts>""")
     val elem1 = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(
       IndexableValue("1.1", Left(elem1_kv))
     ))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual
       """{"objectID":"6/53/1","collection":"/db/a1","documentID":53,"obj1":{"nodeId":"1.1","#text":"hello"}}""".stripMargin
   }
 
-  def e29 = {
+  def e30 = {
     val dom1 = dom("""<parts><w><x type="something"/></w></parts>""")
     val elem1 = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem1).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(
       IndexableValue("1.1", Left(elem1_kv))
     ))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual
       """{"objectID":"6/53/1","collection":"/db/a1","documentID":53,"obj1":{"nodeId":"1.1","type":"something"}}""".stripMargin
   }
 
-  def e30 = {
+  def e31 = {
     val dom1 = dom("""<parts><w><x type="something">hello</x></w></parts>""")
     val elem = firstElem(dom1, "x").get
     val elem1_kv = new ElementKV(new QName("x"), serializeElementForObject("obj1", Map.empty, Map.empty)(elem).valueOr(ts => throw ts.head))
     val objects = Seq(Right(IndexableObject("obj1", Seq(
       IndexableValue("1.1", Left(elem1_kv))
     ))))
-    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, Some("1"), None, objects)
+    val indexableRootObject = IndexableRootObject("/db/a1", 6, 53, None, None, Some("1"), None, objects)
     serializeJson(indexableRootObject) mustEqual
       """{"objectID":"6/53/1","collection":"/db/a1","documentID":53,"obj1":{"nodeId":"1.1","type":"something","#text":"hello"}}""".stripMargin
   }
 
   private def serializeJson(indexableRootObject: IndexableRootObject): String = {
     Using(new StringWriter()) { writer =>
-        val mapper = new ObjectMapper
-        mapper.writeValue(writer, indexableRootObject)
-        writer.toString
+      val mapper = new ObjectMapper
+      mapper.writeValue(writer, indexableRootObject)
+      writer.toString
     }.get
   }
 }


### PR DESCRIPTION
https://www.algolia.com/doc/guides/security/api-keys/how-to/user-restricted-access-to-data/
Following Algolia recommandation the `visible_by` attribute can be used to restrict data access
the indexer now has the option to add this attribute in `collection.xconf`

```xml
<collection xmlns="http://exist-db.org/collection-config/1.0">
    <index xmlns:r="http://raskovnik.org">
        <algolia>
            <namespaceMappings>
                <namespaceMapping>
                    <prefix>r</prefix>
                    <namespace>http://raskovnik.org</namespace>
                </namespaceMapping>
            </namespaceMappings>
            <index name="my-algolia-index-1" visibleBy="/path/to/unique-id/r:visibleBy">
               ...
            </index>
        </algolia>
    </index>
</collection>
```