### PR TITLE
[codex] stabilize CI test harness

### DIFF
--- a/scripts/exist-stage.sh
+++ b/scripts/exist-stage.sh
@@ -226,34 +226,34 @@ import pathlib
 import shutil
 import sys
 
-chunk_dir = pathlib.Path(os.environ[\"REMOTE_CHUNK_DIR\"])
-jar_path = pathlib.Path(os.environ[\"REMOTE_JAR_PATH\"])
-partial_path = pathlib.Path(os.environ[\"REMOTE_PARTIAL_PATH\"])
-expected_sha256 = os.environ[\"EXPECTED_SHA256\"]
-expected_size = int(os.environ[\"EXPECTED_SIZE\"])
+chunk_dir = pathlib.Path(os.environ["REMOTE_CHUNK_DIR"])
+jar_path = pathlib.Path(os.environ["REMOTE_JAR_PATH"])
+partial_path = pathlib.Path(os.environ["REMOTE_PARTIAL_PATH"])
+expected_sha256 = os.environ["EXPECTED_SHA256"]
+expected_size = int(os.environ["EXPECTED_SIZE"])
 parts = sorted(path for path in chunk_dir.iterdir() if path.is_file())
 if not parts:
-    raise SystemExit(f\"No uploaded chunks found in {chunk_dir}\")
+    raise SystemExit(f"No uploaded chunks found in {chunk_dir}")
 sha256 = hashlib.sha256()
 size = 0
 success = False
 try:
     partial_path.parent.mkdir(parents=True, exist_ok=True)
-    with partial_path.open(\"wb\") as destination:
+    with partial_path.open("wb") as destination:
         for part in parts:
-            with part.open(\"rb\") as source:
-                for chunk in iter(lambda: source.read(1024 * 1024), b\"\"):
+            with part.open("rb") as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
                     destination.write(chunk)
                     sha256.update(chunk)
                     size += len(chunk)
     digest = sha256.hexdigest()
     if size != expected_size:
-        raise SystemExit(f\"Uploaded jar size mismatch: expected {expected_size}, got {size}\")
+        raise SystemExit(f"Uploaded jar size mismatch: expected {expected_size}, got {size}")
     if digest != expected_sha256:
-        raise SystemExit(f\"Uploaded jar sha256 mismatch: expected {expected_sha256}, got {digest}\")
+        raise SystemExit(f"Uploaded jar sha256 mismatch: expected {expected_sha256}, got {digest}")
     partial_path.replace(jar_path)
     success = True
-    print(f\"[stage] Remote jar verified: {jar_path} ({size} bytes, sha256={digest})\")
+    print(f"[stage] Remote jar verified: {jar_path} ({size} bytes, sha256={digest})")
 finally:
     shutil.rmtree(chunk_dir, ignore_errors=True)
     if not success and partial_path.exists():

--- a/scripts/test-stage-wrapper.sh
+++ b/scripts/test-stage-wrapper.sh
@@ -155,6 +155,8 @@ run_upload_wrapper_test() {
 
   assert_contains "REMOTE_JAR_PATH=${EXIST_STAGE_REMOTE_DIR}/target/scala-${SCALA_BINARY_VERSION}/${PLUGIN_JAR_FILENAME}" "${SSH_LOG}" "remote jar reassembly target missing"
   assert_contains "REMOTE_PARTIAL_PATH=${EXIST_STAGE_REMOTE_DIR}/target/scala-${SCALA_BINARY_VERSION}/${PLUGIN_JAR_FILENAME}\\.partial" "${SSH_LOG}" "remote partial jar path missing"
+  assert_contains 'os\.environ\["REMOTE_CHUNK_DIR"\]' "${SSH_LOG}" "remote python reassembly snippet missing unescaped env lookup"
+  assert_not_contains '\\\\"REMOTE_CHUNK_DIR\\\\"' "${SSH_LOG}" "remote python reassembly snippet should not contain escaped quotes"
   pass "upload uses chunked jar transfer and remote reassembly"
 }
 

--- a/src/main/scala/org/humanistika/exist/index/algolia/backend/IndexLocalStoreManagerActor.scala
+++ b/src/main/scala/org/humanistika/exist/index/algolia/backend/IndexLocalStoreManagerActor.scala
@@ -132,6 +132,7 @@ object IndexLocalStoreActor {
 class IndexLocalStoreActor(indexesDir: Path, indexName: String, indexingStatusStore: IndexingStatusStore) extends Actor {
   def this(indexesDir: Path, indexName: String) = this(indexesDir, indexName, IndexingStatusStore.noop)
 
+  private lazy val logger = Logger(classOf[IndexLocalStoreActor])
   private val localIndexStoreDir = indexesDir.resolve(indexName)
   private var processing: Map[DocumentId, Timestamp] = Map.empty
   private var perDocumentActors: Map[DocumentId, ActorRef] = Map.empty
@@ -210,9 +211,16 @@ class IndexLocalStoreActor(indexesDir: Path, indexName: String, indexingStatusSt
   private def rootObjectsByCollectionTree(timestampDir: Path, collectionPath: CollectionPath): Seq[Path] = {
     def matchesCollectionPathRoot(rootObjectPath: Path): Boolean = {
       val objectMapper = new ObjectMapper()
-      val tree = objectMapper.readTree(rootObjectPath.toFile)
-      val rootObjectCollectionPath = Option(tree.get(COLLECTION_PATH_FIELD_NAME)).flatMap(node => Option(node.asText))
-      rootObjectCollectionPath.exists(IndexLocalStoreManagerActor.collectionPathMatchesTree(collectionPath, _))
+      Try(objectMapper.readTree(rootObjectPath.toFile)) match {
+        case Success(tree) =>
+          val rootObjectCollectionPath = Option(tree.get(COLLECTION_PATH_FIELD_NAME)).flatMap(node => Option(node.asText))
+          rootObjectCollectionPath.exists(IndexLocalStoreManagerActor.collectionPathMatchesTree(collectionPath, _))
+        case Failure(_) if !Files.exists(rootObjectPath) =>
+          logger.debug(s"Skipping disappeared local-store object during collection removal scan: $rootObjectPath")
+          false
+        case Failure(t) =>
+          throw t
+      }
     }
 
     Using(Files.list(timestampDir)) { timestampDirStream =>

--- a/src/test/scala/org/humanistika/exist/index/algolia/ExistSpecHelper.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/ExistSpecHelper.scala
@@ -27,6 +27,7 @@
 package org.humanistika.exist.index.algolia
 
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.util.{Properties, Optional => JOptional}
 import java.util.UUID
@@ -97,8 +98,20 @@ trait ExistServerStartStopHelper {
 
         val name = instanceName.getOrElse(s"${ScalaBrokerPoolBridge.DEFAULT_INSTANCE_NAME}-${UUID.randomUUID().toString}")
         val home = Option(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths.get(_))
-        val confFile = configFile.getOrElse(ConfigurationHelper.lookup("conf.xml", home.asJava))
+        val originalConfFile = configFile.getOrElse(ConfigurationHelper.lookup("conf.xml", home.asJava))
         try {
+          if(useTemporaryStorage) {
+            this.temporaryStorage = Option(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"))
+            System.out.println("Using temporary storage location: " + temporaryStorage.get.toAbsolutePath().toString())
+          }
+
+          val confFile =
+            if (useTemporaryStorage && originalConfFile.isAbsolute && Files.exists(originalConfFile)) {
+              prepareTemporaryConfig(originalConfFile, temporaryStorage.get)
+            } else {
+              originalConfFile
+            }
+
           val config : Configuration =
             if(confFile.isAbsolute() && Files.exists(confFile)) {
               new Configuration(confFile.toAbsolutePath().toString())
@@ -115,10 +128,8 @@ trait ExistServerStartStopHelper {
           }
 
           if(useTemporaryStorage) {
-            this.temporaryStorage = Option(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"))
             config.setProperty(ScalaBrokerPoolBridge.PROPERTY_DATA_DIR, temporaryStorage.get)
             config.setProperty(Journal.RECOVERY_JOURNAL_DIR_ATTRIBUTE, temporaryStorage.get)
-            System.out.println("Using temporary storage location: " + temporaryStorage.get.toAbsolutePath().toString())
           }
 
           ScalaBrokerPoolBridge.configure(name, 1, 5, config, JOptional.empty())
@@ -182,6 +193,26 @@ trait ExistServerStartStopHelper {
       //set the autodeploy trigger enablement back to how it was before this test class
       System.setProperty(AUTODEPLOY_PROPERTY, prevAutoDeploy.getOrElse("off"))
     }
+  }
+
+  private def prepareTemporaryConfig(originalConfFile: Path, temporaryDataDir: Path): Path = {
+    val rewritten = rewritePathAttributes(
+      new String(Files.readAllBytes(originalConfFile), StandardCharsets.UTF_8),
+      temporaryDataDir.toAbsolutePath.toString
+    )
+    val tempConfFile = temporaryDataDir.resolve("conf.xml")
+    Files.write(tempConfFile, rewritten.getBytes(StandardCharsets.UTF_8))
+    tempConfFile
+  }
+
+  private def rewritePathAttributes(xml: String, replacementPath: String): String = {
+    val escapedPath = replacementPath
+      .replace("&", "&amp;")
+      .replace("\"", "&quot;")
+
+    xml
+      .replaceFirst("""files="[^"]*"""", s"""files="$escapedPath"""")
+      .replaceFirst("""journal-dir="[^"]*"""", s"""journal-dir="$escapedPath"""")
   }
 }
 

--- a/src/test/scala/org/humanistika/exist/index/algolia/ExistSpecHelper.scala
+++ b/src/test/scala/org/humanistika/exist/index/algolia/ExistSpecHelper.scala
@@ -29,6 +29,7 @@ package org.humanistika.exist.index.algolia
 import java.io.IOException
 import java.nio.file.{Files, Path, Paths}
 import java.util.{Properties, Optional => JOptional}
+import java.util.UUID
 
 import org.exist.EXistException
 
@@ -94,34 +95,40 @@ trait ExistServerStartStopHelper {
         }
 
 
-        val name = instanceName.getOrElse(ScalaBrokerPoolBridge.DEFAULT_INSTANCE_NAME)
+        val name = instanceName.getOrElse(s"${ScalaBrokerPoolBridge.DEFAULT_INSTANCE_NAME}-${UUID.randomUUID().toString}")
         val home = Option(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths.get(_))
         val confFile = configFile.getOrElse(ConfigurationHelper.lookup("conf.xml", home.asJava))
+        try {
+          val config : Configuration =
+            if(confFile.isAbsolute() && Files.exists(confFile)) {
+              new Configuration(confFile.toAbsolutePath().toString())
+            } else {
+              new Configuration(FileUtils.fileName(confFile), home.asJava)
+            }
 
-        val config : Configuration =
-          if(confFile.isAbsolute() && Files.exists(confFile)) {
-            new Configuration(confFile.toAbsolutePath().toString())
-          } else {
-            new Configuration(FileUtils.fileName(confFile), home.asJava)
+
+          // override any specified config properties
+          for(
+              cfg <- configProperties;
+              entry <- cfg.entrySet().asScala) {
+            config.setProperty(entry.getKey.toString, entry.getValue)
           }
 
+          if(useTemporaryStorage) {
+            this.temporaryStorage = Option(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"))
+            config.setProperty(ScalaBrokerPoolBridge.PROPERTY_DATA_DIR, temporaryStorage.get)
+            config.setProperty(Journal.RECOVERY_JOURNAL_DIR_ATTRIBUTE, temporaryStorage.get)
+            System.out.println("Using temporary storage location: " + temporaryStorage.get.toAbsolutePath().toString())
+          }
 
-        // override any specified config properties
-        for(
-            cfg <- configProperties;
-            entry <- cfg.entrySet().asScala) {
-          config.setProperty(entry.getKey.toString, entry.getValue)
+          ScalaBrokerPoolBridge.configure(name, 1, 5, config, JOptional.empty())
+          activePool = Some(ScalaBrokerPoolBridge.getInstance(name))
+        } catch {
+          case t: Throwable =>
+            cleanupTemporaryStorage()
+            restoreAutoDeploy()
+            throw t
         }
-
-        if(useTemporaryStorage) {
-          this.temporaryStorage = Option(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"))
-          config.setProperty(ScalaBrokerPoolBridge.PROPERTY_DATA_DIR, temporaryStorage.get)
-          config.setProperty(Journal.RECOVERY_JOURNAL_DIR_ATTRIBUTE, temporaryStorage.get)
-          System.out.println("Using temporary storage location: " + temporaryStorage.get.toAbsolutePath().toString())
-        }
-
-        ScalaBrokerPoolBridge.configure(name, 1, 5, config, JOptional.empty())
-        activePool = Some(ScalaBrokerPoolBridge.getInstance(name))
     }
   }
 
@@ -147,26 +154,33 @@ trait ExistServerStartStopHelper {
   def stopDb() {
     activePool match {
       case None =>
-        throw new IllegalStateException("ExistEmbeddedServer already stopped")
+        cleanupTemporaryStorage()
+        restoreAutoDeploy()
 
       case Some(pool) =>
         pool.shutdown()
 
         // clear instance variables
         activePool = None
+        cleanupTemporaryStorage()
+        restoreAutoDeploy()
+    }
+  }
 
-        temporaryStorage match {
-          case Some(tempStrorage) =>
-            FileUtils.deleteQuietly(tempStrorage)
-            temporaryStorage = None
+  private def cleanupTemporaryStorage(): Unit = {
+    temporaryStorage match {
+      case Some(tempStrorage) =>
+        FileUtils.deleteQuietly(tempStrorage)
+        temporaryStorage = None
 
-          case None =>
-        }
+      case None =>
+    }
+  }
 
-        if(disableAutoDeploy) {
-          //set the autodeploy trigger enablement back to how it was before this test class
-          System.setProperty(AUTODEPLOY_PROPERTY, prevAutoDeploy.getOrElse("off"))
-        }
+  private def restoreAutoDeploy(): Unit = {
+    if(disableAutoDeploy) {
+      //set the autodeploy trigger enablement back to how it was before this test class
+      System.setProperty(AUTODEPLOY_PROPERTY, prevAutoDeploy.getOrElse("off"))
     }
   }
 }


### PR DESCRIPTION
## What changed

- assign a unique embedded eXist broker-pool name to unnamed integration test runs so parallel matrix jobs do not contend for the default instance name
- make test teardown idempotent after startup failures and always clean temporary storage plus autodeploy state
- tolerate a local-store JSON file disappearing during collection-delete scans instead of failing the actor with a FileNotFoundException

## Why it changed

Current GitHub Actions failures on May 19, 2026 showed two separate CI-only failure paths:

- `windows-latest, 21` hit a journal lock during embedded eXist startup and then failed again in teardown with `ExistEmbeddedServer already stopped`
- `macos-latest, 17` failed `IndexLocalStoreManagerActorSpec` when a collection-delete scan tried to read `child.json` after it had already disappeared

This patch stabilizes the test harness and makes the local-store scan resilient to that file-system race without changing indexing semantics.

## Impact

- reduces false-negative CI failures across the matrix
- keeps collection-delete scans focused on real local-store inconsistencies instead of transient file disappearance during cleanup

## Validation

- `sbt --batch test`
- `sbt --batch assembly`
- `./scripts/test-indexing-status-verifier.sh`
- `./scripts/test-stage-wrapper.sh`
- `bash ./scripts/test-collection-sync-flow.sh`
- `bash -n scripts/exist-common.sh scripts/exist-local.sh scripts/exist-stage.sh scripts/exist-stage-remote.sh scripts/exist-production-hotpatch.sh`
- `git diff --check`
